### PR TITLE
fix: do not normalize the user provided endpoint

### DIFF
--- a/aws_mcp_proxy/server.py
+++ b/aws_mcp_proxy/server.py
@@ -31,7 +31,6 @@ from aws_mcp_proxy.mcp_proxy_manager import McpProxyManager
 from aws_mcp_proxy.utils import (
     create_transport_with_sigv4,
     determine_service_name,
-    normalize_endpoint_url,
 )
 from fastmcp.server.server import FastMCP
 from typing import Any
@@ -57,11 +56,8 @@ async def setup_mcp_mode(mcp: FastMCP, args) -> None:
     )
     logger.info('Running in MCP mode')
 
-    # Normalize endpoint URL
-    endpoint_url = normalize_endpoint_url(args.endpoint)
-
     # Create transport with SigV4 authentication
-    transport = create_transport_with_sigv4(endpoint_url, service, profile)
+    transport = create_transport_with_sigv4(args.endpoint, service, profile)
 
     # Create proxy with the transport
     proxy = FastMCP.as_proxy(transport)

--- a/aws_mcp_proxy/utils.py
+++ b/aws_mcp_proxy/utils.py
@@ -51,22 +51,6 @@ def create_transport_with_sigv4(
     )
 
 
-def normalize_endpoint_url(endpoint: str, path: str = '/mcp') -> str:
-    """Normalize endpoint URL by ensuring it has the correct path.
-
-    Args:
-        endpoint: The base endpoint URL
-        path: The path to append (defaults to '/mcp')
-
-    Returns:
-        Normalized endpoint URL
-    """
-    endpoint_url = endpoint.rstrip('/')
-    if not endpoint_url.endswith(path):
-        endpoint_url += path
-    return endpoint_url
-
-
 def determine_service_name(endpoint: str, service: Optional[str] = None) -> str:
     """Validate and determine the service name.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,6 @@ import pytest
 from aws_mcp_proxy.utils import (
     create_transport_with_sigv4,
     determine_service_name,
-    normalize_endpoint_url,
 )
 from fastmcp.client.transports import StreamableHttpTransport
 from unittest.mock import MagicMock, patch
@@ -83,40 +82,6 @@ class TestCreateTransportWithSigv4:
         else:
             # If we can't access the factory directly, just verify the transport was created
             assert result is not None
-
-
-class TestNormalizeEndpointUrl:
-    """Test cases for normalize_endpoint_url function (lines 151-153)."""
-
-    def test_normalize_endpoint_url_default_path(self):
-        """Test normalizing endpoint URL with default /mcp path."""
-        endpoint = 'https://eks-mcp.us-west-2.api.aws'
-        result = normalize_endpoint_url(endpoint)
-        assert result == 'https://eks-mcp.us-west-2.api.aws/mcp'
-
-    def test_normalize_endpoint_url_custom_path(self):
-        """Test normalizing endpoint URL with custom path."""
-        endpoint = 'https://eks-mcp.us-west-2.api.aws'
-        result = normalize_endpoint_url(endpoint, '/api/v1')
-        assert result == 'https://eks-mcp.us-west-2.api.aws/api/v1'
-
-    def test_normalize_endpoint_url_trailing_slash(self):
-        """Test normalizing endpoint URL that already has trailing slash."""
-        endpoint = 'https://eks-mcp.us-west-2.api.aws/'
-        result = normalize_endpoint_url(endpoint)
-        assert result == 'https://eks-mcp.us-west-2.api.aws/mcp'
-
-    def test_normalize_endpoint_url_already_has_path(self):
-        """Test normalizing endpoint URL that already has the path."""
-        endpoint = 'https://eks-mcp.us-west-2.api.aws/mcp'
-        result = normalize_endpoint_url(endpoint)
-        assert result == 'https://eks-mcp.us-west-2.api.aws/mcp'
-
-    def test_normalize_endpoint_url_different_existing_path(self):
-        """Test normalizing endpoint URL that has a different existing path."""
-        endpoint = 'https://eks-mcp.us-west-2.api.aws/api'
-        result = normalize_endpoint_url(endpoint)
-        assert result == 'https://eks-mcp.us-west-2.api.aws/api/mcp'
 
 
 class TestValidateRequiredArgs:


### PR DESCRIPTION
*Description of changes:*


Users of `aws-mcp-proxy` can connect to their private MCP servers deployed to bedrock agentcore runtime. They get back a URL like below:

```python
agent_arn = "arn:aws:bedrock-agentcore:us-west-2:<account-id>:runtime/private-mcp-server-id"
encoded_arn = agent_arn.replace(':', '%3A').replace('/', '%2F')
mcp_url = f"https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/{encoded_arn}/invocations?qualifier=DEFAULT"
```

Check https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-mcp.html for details.

In this case, the MCP endpoint url should not be normalized.


From users perspective, this also does not make sense. `/mcp` is just a convention, not a requirement for streamable-http servers.

### Testing

Successfully connected to my remote MCP on agentcore runtime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
