### PR TITLE
chore: Add commitizen pre-push hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,10 @@ repos:
     - id: ruff
       args: [ --fix ]
     - id: ruff-format
+
+-   repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.9.1
+    hooks:
+      - id: commitizen
+      - id: commitizen-branch
+        stages: [pre-push]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ exclude = ["**/__pycache__", "**/.venv", "**/node_modules", "**/dist", "**/build
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.0.0"
+version = "0.1.0"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",


### PR DESCRIPTION
*Description*

* Commitizen validates [Conventional Commits](https://www.conventionalcommits.org/) as part of pre-commit hook
* Helps with [keeping CHANCHELOG.md](https://keepachangelog.com/en/1.1.0/) up to date. When running `cz bump` it updates the package version, and updates the changelog with corresponding commit messages.

See: https://commitizen-tools.github.io/commitizen/


