### PR TITLE
Update Bandit to properly exclude Tests folder

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -47,7 +47,7 @@ jobs:
           # Report only issues of a given confidence level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
           # confidence: # optional, default is UNDEFINED
           # comma-separated list of paths (glob patterns supported) to exclude from scan (note that these are in addition to the excluded paths provided in the config file) (default: .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
-          excluded_paths: tests,.venv
+          excluded_paths: /tests/,/.venv/
 
           # comma-separated list of test IDs to skip
           # skips: # optional, default is DEFAULT


### PR DESCRIPTION
## Summary

### Changes

Fixing Bandit code scanner to exclude the tests and .venv folder. This should remove the "assert" issue we are seeing in all PRs

### User experience

NA

### Testing

I installed `bandit` locally, and could get it working correctly with the following command

```
bandit -r . -x "/tests/,/.venv/"
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/aws/aws-mcp-proxy/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)
* [ ] Yes
* [X] No

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
