### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@
 
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Creating a minimal update, to see if the configure button will get enabled for Dependabot updates.

The button in the Settings page is not automatically picking up the existing file. It keeps taking me to the "dependabot.yml" file with the expectation that I need to create the file. 

You can see from the documentation, the space between "version" and "updates" is not needed. https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/aws-mcp-proxy/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)
* [ ] Yes
* [ ] No

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
