### PR TITLE
Fix: Fallback to default Botocore behaviour when no profile

### DIFF
--- a/aws_mcp_proxy/server.py
+++ b/aws_mcp_proxy/server.py
@@ -54,9 +54,7 @@ async def setup_mcp_mode(local_mcp: FastMCP, args) -> None:
     profile = args.profile
 
     # Log server configuration
-    logger.info(
-        'Using service: %s, region: %s, profile: %s', service, region, profile or 'default'
-    )
+    logger.info('Using service: %s, region: %s, profile: %s', service, region, profile)
     logger.info('Running in MCP mode')
 
     # Create transport with SigV4 authentication
@@ -101,13 +99,13 @@ Examples:
     parser.add_argument(
         '--profile',
         help='AWS profile to use (uses AWS_PROFILE environment variable if not provided)',
-        default=os.getenv('AWS_PROFILE', 'default'),
+        default=os.getenv('AWS_PROFILE'),
     )
 
     parser.add_argument(
         '--region',
-        help='AWS region to use (uses AWS_REGION if not provided)',
-        default=os.getenv('AWS_REGION', 'default'),
+        help='AWS region to use (uses AWS_REGION environment variable if not provided, with final fallback to us-east-1)',
+        default=os.getenv('AWS_REGION', 'us-east-1'),
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Summary

### Changes

There is a bug, where Botocore is expecting to read a profile called "Default" from the creds, but this is not always guaranteed to exist. Our Creds code is correctly setup to handle the default scenario, but we accidentally set the default Profile to a string, which made it impossible to go into the correct code path.

You can see the same error inside the Current [[Integ test workflow.](https://github.com/aws/aws-mcp-proxy/actions/runs/18279602157/job/52039350775)]

```
  File "/home/runner/work/aws-mcp-proxy/aws-mcp-proxy/aws_mcp_proxy/sigv4_helper.py", line 138, in create_aws_session
    raise ValueError(f"Failed to create AWS session with profile '{profile}': {e}")
ValueError: Failed to create AWS session with profile 'default': The config profile (default) could not be found
```

### Testing

```bash 
# Get credentials for ENV setting
 aws configure export-credentials --profile default --format env

# Clear out existing Creds from file
vim ~/.aws/credentials

# Run Integ test
uv run pytest -m integ
```

Before this change, the Server would fail to start complaining that the profile "default" does not exist. Afterwards, it succeeds.





### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/aws/aws-mcp-proxy/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)
* [ ] Yes
* [X] No

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
