### PR TITLE
Disable retries by default.

### DIFF
--- a/aws_mcp_proxy/server.py
+++ b/aws_mcp_proxy/server.py
@@ -124,10 +124,10 @@ Examples:
     parser.add_argument(
         '--retries',
         type=int,
-        default=3,
+        default=0,
         choices=range(0, 11),
         metavar='[0-10]',
-        help='Number of retries when calling endpoint mcp (default: 3) - setting this to 0 disables retries.',
+        help='Number of retries when calling endpoint mcp (default: 0) - setting this to 0 disables retries.',
     )
 
     return parser.parse_args()


### PR DESCRIPTION
## Summary

### Changes

To avoid potential multiplicative retries, we set retries to 0 by default.

### User experience

> Please share what the user experience looks like before and after this change
Retries will now be handled by the client customers use to invoke the proxy per default. If retries should be attempted via the proxy the use can still enable it via `--retries` parameter

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/aws-mcp-proxy/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)
* [ ] Yes
* [x] No

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
