### PR TITLE
fix: Add region param to Integ Test flow

### DIFF
--- a/tests/integ/mcp/simple_mcp_client.py
+++ b/tests/integ/mcp/simple_mcp_client.py
@@ -51,6 +51,12 @@ def _build_mcp_config(endpoint: str, region_name: str):
 
     return {
         'command': 'aws-mcp-proxy',
-        'args': [endpoint, '--log-level', 'DEBUG'],
+        'args': [
+            endpoint,
+            '--log-level',
+            'DEBUG',
+            '--region',
+            region_name,
+        ],
         'env': environment_variables,
     }


### PR DESCRIPTION
## Summary

### Changes

Add explicit Region into Integ test flow. This should hopefully fix the current issue with our integ tests. [[Last failed run](https://github.com/aws/aws-mcp-proxy/actions/runs/18287338811/job/52065717319)]

I was not able to find this issue from the run logs, so I had to debug it by running the test locally against my own personal account. I found the current issue, and am hoping the Integ test faced the same issue

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/aws/aws-mcp-proxy/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)
* [ ] Yes
* [X] No

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
