### PR TITLE
fix(server.py,-utils.py): fix issue where regions weren't parsed prop…

### DIFF
--- a/aws_mcp_proxy/server.py
+++ b/aws_mcp_proxy/server.py
@@ -47,9 +47,11 @@ async def setup_mcp_mode(local_mcp: FastMCP, args) -> None:
 
     # Validate and determine service
     service = determine_service_name(args.endpoint, args.service)
+    logger.debug('Using service: %s', service)
 
     # Validate and determine region
     region = determine_aws_region(args.endpoint, args.region)
+    logger.debug('Using region: %s', region)
 
     # Get profile
     profile = args.profile
@@ -134,7 +136,7 @@ Examples:
     parser.add_argument(
         '--region',
         help='AWS region to use (uses AWS_REGION environment variable if not provided, with final fallback to us-east-1)',
-        default=os.getenv('AWS_REGION', 'us-east-1'),
+        default=None,
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Summary


Ensure that regions are resolved in the following order: 
1. from --region param 
2. from url 
3. from environment variable and throws an error if none of these are available.

### Changes

> the logic in `determine_aws_regions` was changed to reflect desired behavior.

### User experience

> The regions should be resolved in a more logical order and fail if no region can be resolved.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/aws-mcp-proxy/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)
* [ ] Yes
* [x] No

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
