### PR TITLE
Encourage usage of latest deployed MCP proxy in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The proxy handles [SigV4](https://docs.aws.amazon.com/IAM/latest/UserGuide/refer
 
 ```
 # Run the server
-uvx aws-mcp-proxy <SigV4 MCP endpoint URL>
+uvx aws-mcp-proxy@latest <SigV4 MCP endpoint URL>
 ```
 
 ### Using Local Repository


### PR DESCRIPTION
## Summary
We want users with `uvx` to always use the latest version of the code per default, updating the README accordingly.
This is done with the @latest annotation: https://docs.astral.sh/uv/concepts/tools/#tool-versions
If omitted the cached version (which may be outdated) would be used after initial install. 

### Changes
Update to README

### User experience
Customers who follow the readme will always pull latest version from PyPi if following our instructions.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/aws/aws-mcp-proxy/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [ ] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [X] No

Please add details about how this change was tested.

- [X] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
