### PR TITLE
bump up httpx time out to 180

### DIFF
--- a/aws_mcp_proxy/sigv4_helper.py
+++ b/aws_mcp_proxy/sigv4_helper.py
@@ -202,7 +202,7 @@ def create_sigv4_client(
     # Create a copy of kwargs to avoid modifying the passed dict
     client_kwargs = {
         'follow_redirects': True,
-        'timeout': httpx.Timeout(120.0, connect=60.0, read=120.0, write=60.0),
+        'timeout': httpx.Timeout(180.0, connect=60.0, read=120.0, write=180.0),
         'limits': httpx.Limits(max_keepalive_connections=1, max_connections=5),
         **kwargs,
     }


### PR DESCRIPTION
## Summary

Some servers requires long time out due to the tool execution.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/aws-mcp-proxy/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
