### PR TITLE
test(Increase-timeout-of-integrationt-test.): Increase timeout to 30 seconds

### DIFF
--- a/tests/integ/mcp/simple_mcp_client.py
+++ b/tests/integ/mcp/simple_mcp_client.py
@@ -18,7 +18,7 @@ def build_mcp_client(endpoint: str, region_name: str) -> fastmcp.Client:
             )
         ),
         elicitation_handler=_basic_elicitation_handler,
-        timeout=10.0,  # seconds
+        timeout=30.0,  # seconds
     )
 
 


### PR DESCRIPTION
## Summary
Integ test is broken due to timeout, increasing it fixes the issue.

### Changes

Timeout increased to 30 seconds.

### User experience

N/a
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [X] No

Please add details about how this change was tested.

- [X] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
