### PR TITLE
docs: Remove --endpoint from DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,23 +96,21 @@ git commit -m "feat: add new feature description"
 #### Basic Local Execution
 ```bash
 # Run the server directly
-uv run mcp_proxy_for_aws/server.py --endpoint <your-endpoint>
+uv run mcp_proxy_for_aws/server.py <your-endpoint>
 ```
 
 #### With MCP Inspector (for debugging)
 ```bash
 # Run with MCP inspector for interactive debugging
 npx @modelcontextprotocol/inspector uv run \
-  mcp_proxy_for_aws/server.py \
-  --endpoint <your-endpoint>
+  mcp_proxy_for_aws/server.py <your-endpoint>
 ```
 A browser window will open automatically outside of your terminal window. Navigate to the browser window. Then click "Connect" in the opened browser window to interact with the server.
 
 #### Advanced Options
 ```bash
 # Run with specific AWS profile and write permissions
-uv run mcp_proxy_for_aws/server.py \
-  --endpoint <your-endpoint> \
+uv run mcp_proxy_for_aws/server.py <your-endpoint> \
   --service <aws-service> \
   --profile <aws-profile> \
   --allow-write
@@ -378,7 +376,7 @@ Enable debug logging for troubleshooting:
 ```bash
 # Set logging level to debug
 export LOG_LEVEL=DEBUG
-uv run mcp_proxy_for_aws/server.py --endpoint <endpoint>
+uv run mcp_proxy_for_aws/server.py <endpoint>
 ```
 
 ## Additional Resources


### PR DESCRIPTION
## Summary

### Changes

There was several mentions of `--endpoint` in DEVELOPMENT.md

### User experience

They can now use the examples in `DEVELOPMENT.md` directly.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [X] No

Please add details about how this change was tested.

- [X] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
