### PR TITLE
fix: do not raise errors. Let mcp sdk handle the http errors

### DIFF
--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -70,15 +70,7 @@ class TestHandleErrorResponse:
             request=request,
         )
 
-        # Test that the function raises HTTPStatusError with enhanced message
-        with pytest.raises(httpx.HTTPStatusError) as exc_info:
-            await _handle_error_response(response)
-
-        # Verify the error message contains the JSON details
-        error_msg = str(exc_info.value)
-        assert '404' in error_msg
-        assert 'Not Found' in error_msg
-        assert 'https://example.com/test' in error_msg
+        await _handle_error_response(response)
 
     @pytest.mark.asyncio
     async def test_handle_error_response_with_non_json_error(self):
@@ -92,12 +84,7 @@ class TestHandleErrorResponse:
             request=request,
         )
 
-        # Test that the function raises HTTPStatusError
-        with pytest.raises(httpx.HTTPStatusError) as exc_info:
-            await _handle_error_response(response)
-
-        # Verify the error contains status code information
-        assert exc_info.value.response.status_code == 500
+        await _handle_error_response(response)
 
     @pytest.mark.asyncio
     async def test_handle_error_response_with_success_response(self):
@@ -111,11 +98,7 @@ class TestHandleErrorResponse:
             request=request,
         )
 
-        # Test that no exception is raised for successful responses
-        try:
-            await _handle_error_response(response)
-        except Exception as e:
-            pytest.fail(f'Unexpected exception raised for success response: {e}')
+        await _handle_error_response(response)
 
     @pytest.mark.asyncio
     async def test_handle_error_response_with_read_failure(self):
@@ -135,9 +118,7 @@ class TestHandleErrorResponse:
             )
         )
 
-        # Test that the function still raises HTTPStatusError even when reading fails
-        with pytest.raises(httpx.HTTPStatusError):
-            await _handle_error_response(response)
+        await _handle_error_response(response)
 
     @pytest.mark.asyncio
     async def test_handle_error_response_with_invalid_json(self):
@@ -151,9 +132,7 @@ class TestHandleErrorResponse:
             request=request,
         )
 
-        # Test that the function raises HTTPStatusError even with invalid JSON
-        with pytest.raises(httpx.HTTPStatusError):
-            await _handle_error_response(response)
+        await _handle_error_response(response)
 
 
 class TestCreateAwsSession:


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

As a MCP proxy, we should not handle the HTTP transport error for the MCP SDK. Remove the `raise_for_status` call,

### User experience

> Please share what the user experience looks like before and after this change

No user experience should change after this change because the python mcp sdk already handles the errors by themselves.

```
> rg raise_for_status src/

src/mcp/client/streamable_http.py
211:                event_source.response.raise_for_status()
240:            event_source.response.raise_for_status()
278:            response.raise_for_status()

src/mcp/client/sse.py
66:                    event_source.response.raise_for_status()
131:                                    response.raise_for_status()

src/mcp/server/fastmcp/resources/types.py
160:            response.raise_for_status()
```

Fix bug for deleting session because the mcp sdk calls `raise_for_status` [after some checking status code 404](https://github.com/tonyxwz/mcp-python-sdk/blob/ca3466666310dbcb5c45690ac2571c574759984f/src/mcp/client/streamable_http.py#L270-L276).

If we raise the error in the httpx event hooks, the error would make deleting session fail.


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
