### PR TITLE
fix: f-strings formatting in logging

### DIFF
--- a/mcp_proxy_for_aws/middleware/tool_filter.py
+++ b/mcp_proxy_for_aws/middleware/tool_filter.py
@@ -34,7 +34,7 @@ class ToolFilteringMiddleware(Middleware):
         """Filter tools based on read only flag."""
         # Get list of FastMCP Components
         tools = await call_next(context)
-        self.logger.info(f'Filtering tools for read only: {self.read_only}')
+        self.logger.info('Filtering tools for read only: %s', self.read_only)
 
         # If not read only, return the list of tools as is
         if not self.read_only:
@@ -49,7 +49,7 @@ class ToolFilteringMiddleware(Middleware):
             read_only_hint = getattr(annotations, 'readOnlyHint', False)
             if not read_only_hint:
                 # Skip tools that don't have readOnlyHint=True
-                self.logger.info(f'Skipping tool {tool.name} needing write permissions')
+                self.logger.info('Skipping tool %s needing write permissions', tool.name)
                 continue
 
             filtered_tools.append(tool)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ force-exclude = true
 
 [tool.ruff.lint]
 exclude = ["__init__.py"]
-select = ["C", "D", "E", "F", "I", "W"]
+select = ["C", "D", "E", "F", "G", "I", "W"]
 ignore = ["C901", "E501", "E741", "F402", "F823", "D100", "D106"]
 
 [tool.ruff.lint.isort]

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -77,10 +77,14 @@ def _build_endpoint_environment_remote_configuration():
 
     region_name = os.environ.get('AWS_REGION')
     if not region_name:
-        logger.warn('AWS_REGION param not set. Defaulting to us-east-1')
+        logger.warning('AWS_REGION param not set. Defaulting to us-east-1')
         region_name = 'us-east-1'
 
-    logger.info(f'Starting server with config - {remote_endpoint_url=} and {region_name=}')
+    logger.info(
+        'Starting server with config - remote_endpoint_url=%s and region_name=%s',
+        remote_endpoint_url,
+        region_name,
+    )
 
     return RemoteMCPServerConfiguration(
         endpoint=remote_endpoint_url,

--- a/tests/integ/mcp/simple_mcp_client.py
+++ b/tests/integ/mcp/simple_mcp_client.py
@@ -23,7 +23,7 @@ def build_mcp_client(endpoint: str, region_name: str) -> fastmcp.Client:
 
 
 async def _basic_elicitation_handler(message: str, response_type: type, params, context):
-    logger.info(f'Server asks: {message} with response_type {response_type}')
+    logger.info('Server asks: %s with response_type %s', message, response_type)
 
     # Usually the Handler would expect an user Input to control flow via Accept, Decline, Cancel
     # But in this Integ test we only care that an Elicitation request went through the handler

--- a/tests/integ/test_proxy_dynamic_tools.py
+++ b/tests/integ/test_proxy_dynamic_tools.py
@@ -18,7 +18,7 @@ async def test_proxy_reflects_tool_addition(mcp_client: fastmcp.Client, is_using
     initial_tools = await mcp_client.list_tools()
     initial_tool_names = [tool.name for tool in initial_tools]
 
-    logger.info(f'Initial tools: {initial_tool_names}')
+    logger.info('Initial tools: %s', initial_tool_names)
 
     # Verify 'multiply' tool doesn't exist yet
     assert 'multiply' not in initial_tool_names, 'multiply tool should not exist initially'
@@ -26,13 +26,13 @@ async def test_proxy_reflects_tool_addition(mcp_client: fastmcp.Client, is_using
     # Act - Trigger backend to dynamically add a new tool
     logger.info('Calling add_tool_multiply to add a new tool to the backend')
     add_result = await mcp_client.call_tool('add_tool_multiply', {})
-    logger.info(f'Backend response: {add_result}')
+    logger.info('Backend response: %s', add_result)
 
     # Get updated tool list
     updated_tools = await mcp_client.list_tools()
     updated_tool_names = [tool.name for tool in updated_tools]
 
-    logger.info(f'Updated tools: {updated_tool_names}')
+    logger.info('Updated tools: %s', updated_tool_names)
 
     # Assert
     # The proxy should reflect the newly added tool


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

- Replacing f-strings with lazy `%` formatting in all logging statements
- Adding ruff's `G` rule (flake8-logging-format) to automatically enforce logging

### User experience

> Please share what the user experience looks like before and after this change

No changes.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
