### PR TITLE
fix: correct log_level type annotation  in add_logging_middleware

### DIFF
--- a/mcp_proxy_for_aws/server.py
+++ b/mcp_proxy_for_aws/server.py
@@ -111,7 +111,7 @@ def add_retry_middleware(mcp: FastMCP, retries: int) -> None:
     mcp.add_middleware(RetryMiddleware(retries))
 
 
-def add_logging_middleware(mcp: FastMCP, log_level: int) -> None:
+def add_logging_middleware(mcp: FastMCP, log_level: str) -> None:
     """Add logging middleware."""
     if log_level != 'DEBUG':
         return


### PR DESCRIPTION
## Summary

Fix type annotation mismatch in `add_logging_middleware` function. 

The `log_level` parameter was incorrectly annotated as `int` but actually receives string values (`'DEBUG'`, `'INFO'`, `'WARNING'`, `'ERROR'`, `'CRITICAL'`) from argparse.

### Changes

Changed `log_level` parameter type annotation from `int` to `str` in `add_logging_middleware()` function in `mcp_proxy_for_aws/server.py`

### User experience

No user-facing changes. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
