### PR TITLE
fix logging and set default logging level to ERROR

### DIFF
--- a/mcp_proxy_for_aws/cli.py
+++ b/mcp_proxy_for_aws/cli.py
@@ -73,8 +73,8 @@ Examples:
     parser.add_argument(
         '--log-level',
         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-        default='INFO',
-        help='Set the logging level (default: INFO)',
+        default='ERROR',
+        help='Set the logging level (default: ERROR)',
     )
 
     parser.add_argument(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -32,7 +32,7 @@ class TestParseArgs:
         assert args.profile is None
         assert args.region is None
         assert args.read_only is False
-        assert args.log_level == 'INFO'
+        assert args.log_level == 'ERROR'
         assert args.retries == 0
         assert args.timeout == 180.0
         assert args.connect_timeout == 60.0

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -194,7 +194,7 @@ class TestServer:
         assert args.region is None
         assert args.profile is None
         assert args.read_only is False
-        assert args.log_level == 'INFO'
+        assert args.log_level == 'ERROR'
         assert args.retries == 0
 
     @patch(


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

Change the default log level to ERROR otherwise the log is too verbose.

### User experience

> Please share what the user experience looks like before and after this change

Some MCP client (such as cline) seems to have issues if stdio servers log to stderr during the `initialize` phase. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
