### PR TITLE
Improve contrib docs about opening a issue before contributing to large features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,9 @@ Thank you for your interest in contributing to the MCP Proxy for AWS! We welcome
 
 ## Quick Start
 
+> [!NOTE]
+> Before implementing new features, please create an issue first to ensure your contribution aligns with the project roadmap.
+
 1. **Fork the repository** on GitHub
 2. **Set up your development environment** - see [DEVELOPMENT.md](DEVELOPMENT.md) for detailed setup instructions
 3. **Create a feature branch** from `main`


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

Add instruction in contributing guide line to avoid contributor wasting time on large PRs of new feature that cannot be merged. Opening an issue will allow the team to provide feedback earlier.

### User experience

> Please share what the user experience looks like before and after this change

Hopefully we won't have to turn off contributors PRs like https://github.com/aws/mcp-proxy-for-aws/pull/74

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
