### PR TITLE
fix(mcp_proxy_for_aws/utils.py): add override for bedrock-agentcore service name detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ docker build -t mcp-proxy-for-aws .
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|---	|
 | `endpoint`	          | MCP endpoint URL (e.g., `https://your-service.us-east-1.amazonaws.com/mcp`)	                                                                                                                                                            | N/A	                                                                        |Yes	|
 | ---	                 | ---	                                                                                                                                                                                                                                    | ---	                                                                        |---	|
-| `--service`	         | AWS service name for SigV4 signing	                                                                                                                                                                                                     | Inferred from endpoint if not provided	                                     |No	|
+| `--service`	         | AWS service name for SigV4 signing, if omitted we try to infer this from the url	                                                                                                                                                       | Inferred from endpoint if not provided	                                     |No	|
 | `--profile`	         | AWS profile for AWS credentials to use	                                                                                                                                                                                                 | Uses `AWS_PROFILE` environment variable if not set                          |No	|
 | `--region`	          | AWS region to use	                                                                                                                                                                                                                      | Uses `AWS_REGION` environment variable if not set, defaults to `us-east-1`	 |No	|
 | `--metadata`	        | Metadata to inject into MCP requests as key=value pairs (e.g., `--metadata KEY1=value1 KEY2=value2`)                                                                                                                                    | `AWS_REGION` is automatically injected based on `--region` if not provided    |No	|
@@ -278,6 +278,15 @@ uv sync
 ```
 
 ---
+
+## Troubleshooting
+
+### Handling `Authentication error - Invalid credentials`
+We try to autodetect the service from the url, sometimes this fails, ensure that `--service` is set correctly to the
+service you are attempting to connect to.
+Otherwise the SigV4 signing will not be able to be verified by the service you connect to, resulting in this error.
+Also ensure that you have valid IAM credentials on your machine before retrying.
+
 
 ## Development & Contributing
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -136,6 +136,20 @@ class TestValidateRequiredArgs:
         result = determine_service_name(endpoint)
         assert result == 'service'
 
+    def test_validate_service_name_bedrock_agentcore(self):
+        """Test parsing service name for bedrock-agentcore endpoints."""
+        # Test various bedrock-agentcore endpoint formats
+        test_cases = [
+            'https://my-agent.gateway.bedrock-agentcore.us-west-2.amazonaws.com',  # Clean gateway
+            'https://bedrock-agentcore.us-east-1.amazonaws.com',  # Clean runtime
+            'https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-east-1%3A216123456714%3Aruntime%2Fhosted_agent_99wdf-hYKYrgAHVr/invocations',
+            'https://gateway-quick-start-242206-rsdehprct2.gateway.bedrock-agentcore.eu-central-1.amazonaws.com/mcp',
+        ]
+
+        for endpoint in test_cases:
+            result = determine_service_name(endpoint)
+            assert result == 'bedrock-agentcore', f'Failed for endpoint: {endpoint}'
+
     def test_validate_service_name_service_parsing_simple_hostname(self):
         """Test parsing service from simple hostname."""
         endpoint = 'https://myservice'


### PR DESCRIPTION

Fixes failures when connecting to an Agentcore service.

## Summary
Bedrock AgentCore url structure does not align to our current `--service` detection regex. For now i'm adding an override if we realize we will need more overrides as time goes on we should re-evaluate the regex itself.

### Changes

Adding a check for `.bedrock-agentcore.` in the url and using this as service if found. 

### User experience

After fix users connecting to AgentCore can omit the `--service` flag.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [X] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
