### PR TITLE
fix(sigv4_helper.py): reduce severity of log levels

### DIFF
--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -250,9 +250,9 @@ async def _inject_metadata_hook(metadata: Dict[str, Any], request: httpx.Request
         metadata: Dictionary of metadata to inject into _meta field
         request: The HTTP request object
     """
-    logger.info('=== Outgoing Request ===')
-    logger.info('URL: %s', request.url)
-    logger.info('Method: %s', request.method)
+    logger.debug('=== Outgoing Request ===')
+    logger.debug('URL: %s', request.url)
+    logger.debug('Method: %s', request.method)
 
     # Try to inject metadata if it's a JSON-RPC/MCP request
     if request.content and metadata:
@@ -284,7 +284,7 @@ async def _inject_metadata_hook(metadata: Dict[str, Any], request: httpx.Request
                             )
                     body['params']['_meta'] = {**metadata, **existing_meta}
                 else:
-                    logger.info('Replacing non-dict _meta value with injected metadata')
+                    logger.debug('Overwriting _meta value with injected metadata')
                     body['params']['_meta'] = metadata
 
                 # Create new content with updated metadata
@@ -298,4 +298,4 @@ async def _inject_metadata_hook(metadata: Dict[str, Any], request: httpx.Request
 
         except (json.JSONDecodeError, KeyError, TypeError) as e:
             # Not a JSON request or invalid format, skip metadata injection
-            logger.error('Skipping metadata injection: %s', e)
+            logger.debug('Skipping metadata injection: %s', e)


### PR DESCRIPTION


## Summary
Log levels were changed.

### Changes

> Log levels were changed.

### User experience

> The user will now not see error logs when metadata injection is skipped.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [] Changes have been tested
* [] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
