### PR TITLE
Revert "test(Increase-timeout-of-integrationt-test.): Increase timeou…

### DIFF
--- a/tests/integ/mcp/simple_mcp_client.py
+++ b/tests/integ/mcp/simple_mcp_client.py
@@ -27,7 +27,7 @@ def build_mcp_client(
             **_build_mcp_config(endpoint=endpoint, region_name=region_name, metadata=metadata)
         ),
         elicitation_handler=_basic_elicitation_handler,
-        timeout=30.0,  # seconds
+        timeout=10.0,  # seconds
     )
 
 


### PR DESCRIPTION
…t to 30 seconds to fix integration tests (#60)"

This reverts commit c4c7484670ffd9687321ce577d92722a31e635d0.

## Summary

### Changes

> Please provide a summary of what's being changed


Revert the change to increase timeout of integ tests. The timeout was actually an issue because with the transport not being used, the proxy creates session for every requests.

Because we are using stdio which is not aware of the sessionId, the client calls proxy without session ID, and proxy creates a new session.

I think the fastmcp library needs to fix this somehow too, for example, when the proxy is bridging stdio  and streamable-http, it does not make sense not to reuse session.



### User experience

> Please share what the user experience looks like before and after this change

No user experience should be changed.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
