### PR TITLE
lazy initialize the session upon stdio client initializes

### DIFF
--- a/mcp_proxy_for_aws/server.py
+++ b/mcp_proxy_for_aws/server.py
@@ -84,7 +84,7 @@ async def setup_mcp_mode(local_mcp: FastMCP, args) -> None:
     transport = create_transport_with_sigv4(
         args.endpoint, service, region, metadata, timeout, profile
     )
-    async with Client(transport=transport) as client:
+    async with Client(transport=transport, auto_initialize=False) as client:
         # Create proxy with the transport
         proxy = FastMCP.as_proxy(client)
         add_logging_middleware(proxy, args.log_level)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ description = "MCP Proxy for AWS"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "fastmcp>=2.13.0.2",
+    "fastmcp>=2.13.1",
     "boto3>=1.34.0",
     "botocore>=1.34.0",
 ]

--- a/tests/integ/mcp/simple_mcp_server/mcp_server.py
+++ b/tests/integ/mcp/simple_mcp_server/mcp_server.py
@@ -79,8 +79,12 @@ async def elicit_for_my_name(elicitation_expected: str, ctx: Context):
 @mcp.tool
 def echo_metadata(ctx: Context):
     """MCP Tool that echoes back the _meta field from the request."""
-    meta = ctx.request_context.meta
-    return {'received_meta': meta}
+    if ctx.request_context:
+        meta = ctx.request_context.meta
+        return {'received_meta': meta}
+    else:
+        # should not happen, trying to make typechecker happy
+        raise RuntimeError('MCP tool invoked before session is initialized')
 
 
 #### Server Setup

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -99,7 +99,7 @@ class TestServer:
         assert call_args[0][3] == {'AWS_REGION': 'us-east-1'}  # metadata
         # call_args[0][4] is the Timeout object
         assert call_args[0][5] is None  # profile
-        mock_client_class.assert_called_once_with(transport=mock_transport)
+        mock_client_class.assert_called_once_with(transport=mock_transport, auto_initialize=False)
         mock_as_proxy.assert_called_once_with(mock_client)
         mock_add_filtering.assert_called_once_with(mock_proxy, True)
         mock_add_retry.assert_called_once_with(mock_proxy, 1)
@@ -173,7 +173,7 @@ class TestServer:
         }  # metadata
         # call_args[0][4] is the Timeout object
         assert call_args[0][5] == 'test-profile'  # profile
-        mock_client_class.assert_called_once_with(transport=mock_transport)
+        mock_client_class.assert_called_once_with(transport=mock_transport, auto_initialize=False)
         mock_as_proxy.assert_called_once_with(mock_client)
         mock_add_filtering.assert_called_once_with(mock_proxy, False)
         mock_proxy.run_async.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1200,7 +1200,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "2.13.0.2"
+version = "2.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1216,11 +1216,12 @@ dependencies = [
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "rich" },
+    { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/74/584a152bcd174c99ddf3cfdd7e86ec4a6c696fb190a907c2a2ec9056bda2/fastmcp-2.13.0.2.tar.gz", hash = "sha256:d35386561b6f3cde195ba2b5892dc89b8919a721e6b39b98e7a16f9a7c0b8e8b", size = 7762083, upload-time = "2025-10-28T13:56:21.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/a3/c9eb28b5f0b979b0dd8aa9ba56e69298cdb2d72c15592165d042ccb20194/fastmcp-2.13.1.tar.gz", hash = "sha256:b9c664c51f1ff47c698225e7304267ae29a51913f681bd49e442b8682f9a5f90", size = 8170226, upload-time = "2025-11-15T19:02:17.693Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/c6/95eacd687cfab64fec13bfb64e6c6e7da13d01ecd4cb7d7e991858a08119/fastmcp-2.13.0.2-py3-none-any.whl", hash = "sha256:eb381eb073a101aabbc0ac44b05e23fef0cd1619344b7703115c825c8755fa1c", size = 367511, upload-time = "2025-10-28T13:56:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/4b/7e36db0a90044be181319ff025be7cc57089ddb6ba8f3712dea543b9cf97/fastmcp-2.13.1-py3-none-any.whl", hash = "sha256:7a78b19785c4ec04a758d920c312769a497e3f6ab4c80feed504df1ed7de9f3c", size = 376750, upload-time = "2025-11-15T19:02:15.748Z" },
 ]
 
 [[package]]
@@ -2506,7 +2507,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.34.0" },
     { name = "botocore", specifier = ">=1.34.0" },
-    { name = "fastmcp", specifier = ">=2.13.0.2" },
+    { name = "fastmcp", specifier = ">=2.13.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

There is new parameter `auto_initialize` added to the Client in `fastmcp>=2.13.1` (https://github.com/jlowin/fastmcp/releases/tag/v2.13.1)

We need to use this parameter in the proxy because the proxy should accept `initialize` request from stdio, pass it to the `fastmcp.Client` so that the version and capabilities negotiated is what the actual client (such as kiro and kiro desktop) supports. Otherwise, the initialize will use the capability supported by fastmcp and it might mismatch with what the client uses.

### User experience

> Please share what the user experience looks like before and after this change

This is a fix for user experience. User should not experience hanging initialize request any more.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
