### PR TITLE
feat: set client info in user agent in header [Pending Legal Discussion]

### DIFF
--- a/mcp_proxy_for_aws/context.py
+++ b/mcp_proxy_for_aws/context.py
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module-level storage for session-scoped data."""
+
+from mcp.types import Implementation
+from typing import Optional
+
+
+_client_info: Optional[Implementation] = None
+
+
+def get_client_info() -> Optional[Implementation]:
+    """Get the stored client info."""
+    return _client_info
+
+
+def set_client_info(info: Optional[Implementation]) -> None:
+    """Set the client info."""
+    global _client_info
+    _client_info = info

--- a/mcp_proxy_for_aws/middleware/client_info.py
+++ b/mcp_proxy_for_aws/middleware/client_info.py
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from collections.abc import Awaitable, Callable
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+from mcp import types as mt
+from mcp_proxy_for_aws.context import set_client_info
+
+
+logger = logging.getLogger(__name__)
+
+
+class ClientInfoMiddleware(Middleware):
+    """Middleware to capture client_info from initialize method."""
+
+    async def on_initialize(
+        self,
+        context: MiddlewareContext[mt.InitializeRequest],
+        call_next: Callable[[MiddlewareContext[mt.InitializeRequest]], Awaitable[None]],
+    ) -> None:
+        """Capture client_info from initialize request."""
+        if context.message.params and context.message.params.clientInfo:
+            info = context.message.params.clientInfo
+            set_client_info(info)
+            logger.info('Captured client_info: name=%s, version=%s', info.name, info.version)
+
+        await call_next(context)

--- a/mcp_proxy_for_aws/middleware/tool_filter.py
+++ b/mcp_proxy_for_aws/middleware/tool_filter.py
@@ -19,13 +19,15 @@ from fastmcp.tools.tool import Tool
 from typing import Sequence
 
 
+logger = logging.getLogger(__name__)
+
+
 class ToolFilteringMiddleware(Middleware):
     """Middleware to filter tools based on read only flag."""
 
-    def __init__(self, read_only: bool, logger: logging.Logger | None = None):
+    def __init__(self, read_only: bool):
         """Initialize the middleware."""
         self.read_only = read_only
-        self.logger = logger or logging.getLogger(__name__)
 
     async def on_list_tools(
         self,
@@ -35,7 +37,7 @@ class ToolFilteringMiddleware(Middleware):
         """Filter tools based on read only flag."""
         # Get list of FastMCP Components
         tools = await call_next(context)
-        self.logger.info('Filtering tools for read only: %s', self.read_only)
+        logger.info('Filtering tools for read only: %s', self.read_only)
 
         # If not read only, return the list of tools as is
         if not self.read_only:
@@ -50,7 +52,7 @@ class ToolFilteringMiddleware(Middleware):
             read_only_hint = getattr(annotations, 'readOnlyHint', False)
             if not read_only_hint:
                 # Skip tools that don't have readOnlyHint=True
-                self.logger.info('Skipping tool %s needing write permissions', tool.name)
+                logger.info('Skipping tool %s needing write permissions', tool.name)
                 continue
 
             filtered_tools.append(tool)

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -22,6 +22,8 @@ from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.credentials import Credentials
 from functools import partial
+from mcp_proxy_for_aws import __version__
+from mcp_proxy_for_aws.context import get_client_info
 from typing import Any, Dict, Generator, Optional
 
 
@@ -227,6 +229,13 @@ async def _sign_request_hook(
     """
     # Set Content-Length for signing
     request.headers['Content-Length'] = str(len(request.content))
+
+    # Build User-Agent from client_info if available
+    info = get_client_info()
+    if info:
+        user_agent = f'{info.name}/{info.version} mcp-proxy-for-aws/{__version__}'
+        request.headers['User-Agent'] = user_agent
+        logger.info('Set User-Agent header: %s', user_agent)
 
     # Get AWS credentials
     session = create_aws_session(profile)

--- a/tests/unit/test_client_info_middleware.py
+++ b/tests/unit/test_client_info_middleware.py
@@ -1,0 +1,116 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from datetime import datetime
+from fastmcp.server.middleware import MiddlewareContext
+from mcp import types as mt
+from mcp_proxy_for_aws.context import get_client_info, set_client_info
+from mcp_proxy_for_aws.middleware.client_info import ClientInfoMiddleware
+
+
+@pytest.fixture
+def middleware():
+    """Create a ClientInfoMiddleware instance."""
+    return ClientInfoMiddleware()
+
+
+@pytest.fixture
+def mock_context_with_client_info():
+    """Create a mock context with client_info."""
+    params = mt.InitializeRequestParams(
+        protocolVersion='2024-11-05',
+        capabilities=mt.ClientCapabilities(),
+        clientInfo=mt.Implementation(name='test-client', version='1.0.0'),
+    )
+    message = mt.InitializeRequest(
+        method='initialize',
+        params=params,
+    )
+    return MiddlewareContext(
+        message=message,
+        fastmcp_context=None,
+        source='client',
+        type='request',
+        method='initialize',
+        timestamp=datetime.now(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_captures_client_info(middleware, mock_context_with_client_info):
+    """Test that middleware captures client_info from initialize request."""
+    # Reset context variable
+    set_client_info(None)
+
+    async def call_next(ctx):
+        pass
+
+    await middleware.on_initialize(mock_context_with_client_info, call_next)
+
+    # Verify client_info was captured
+    info = get_client_info()
+    assert info is not None
+    assert info.name == 'test-client'
+    assert info.version == '1.0.0'
+
+
+@pytest.mark.asyncio
+async def test_calls_next_middleware(middleware, mock_context_with_client_info):
+    """Test that middleware calls the next middleware in chain."""
+    called = False
+
+    async def call_next(ctx):
+        nonlocal called
+        called = True
+
+    await middleware.on_initialize(mock_context_with_client_info, call_next)
+
+    assert called is True
+
+
+@pytest.mark.asyncio
+async def test_captures_different_client_info(middleware):
+    """Test that middleware captures different client_info values."""
+    # Reset context variable
+    set_client_info(None)
+
+    params = mt.InitializeRequestParams(
+        protocolVersion='2024-11-05',
+        capabilities=mt.ClientCapabilities(),
+        clientInfo=mt.Implementation(name='another-client', version='2.5.3'),
+    )
+    message = mt.InitializeRequest(
+        method='initialize',
+        params=params,
+    )
+    context = MiddlewareContext(
+        message=message,
+        fastmcp_context=None,
+        source='client',
+        type='request',
+        method='initialize',
+        timestamp=datetime.now(),
+    )
+
+    async def call_next(ctx):
+        pass
+
+    await middleware.on_initialize(context, call_next)
+
+    # Verify client_info was captured with correct values
+    info = get_client_info()
+    assert info is not None
+    assert info.name == 'another-client'
+    assert info.version == '2.5.3'

--- a/tests/unit/test_tool_filter.py
+++ b/tests/unit/test_tool_filter.py
@@ -40,7 +40,6 @@ class TestToolFilteringMiddleware:
 
         # Assert
         assert middleware.read_only is False
-        assert middleware.logger is not None
 
     def test_constructor_read_only_true(self):
         """Test constructor with read_only=True."""
@@ -49,7 +48,6 @@ class TestToolFilteringMiddleware:
 
         # Assert
         assert middleware.read_only is True
-        assert middleware.logger is not None
 
 
 class TestOnListTools:


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

Requested by partner teams.

### User experience

> Please share what the user experience looks like before and after this change

No change to the user experience

### Test

Connect to my bedrock runtime, client info user agent is in the headers.

```
2025-11-27 19:22:15.671 [warning] [test] Log from MCP Server: 2025-11-27 19:22:15 | DEBUG | 
mcp_proxy_for_aws.sigv4_helper | Request headers after signing: Headers({'connection': 'keep-alive', 'host': 'bedrock-
agentcore.us-west-2.amazonaws.com', 'accept-encoding': 'gzip, deflate', 'user-agent': 'kiro/0.0.0 mcp-proxy-for-aws/1.1.2', 
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
