### PR TITLE
fix: avoid infinite recursion

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2458,8 +2458,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.34.0" },
-    { name = "botocore", extras = ["crt"], specifier = ">=1.34.0" },
+    { name = "boto3", specifier = ">=1.41.0" },
+    { name = "botocore", extras = ["crt"], specifier = ">=1.41.0" },
     { name = "fastmcp", specifier = ">=2.13.1" },
 ]
 


### PR DESCRIPTION
## Summary

Previously, the `_connect` method retries on RuntimeError. This can cause infinite recursion if
1. the network is down
2. there were legit McpError that terminate the session.

This fix ensures that
1. when a RuntimeError wraps an McpError, the underlying McpError is properly extracted and raised (user does not have the permission to InvokeMcp)
2. connection retries only on TimeoutException for at most 3 times.

### Changes

> Please provide a summary of what's being changed



### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
