### PR TITLE
Add ownership verification for aws-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,3 +317,4 @@ Licensed under the Apache License, Version 2.0 (the "License").
 LLMs are non-deterministic and they make mistakes, we advise you to always thoroughly test and follow the best practices of your organization before using these tools on customer facing accounts. Users of this package are solely responsible for implementing proper security controls and MUST use AWS Identity and Access Management (IAM) to manage access to AWS resources. You are responsible for configuring appropriate IAM policies, roles, and permissions, and any security vulnerabilities resulting from improper IAM configuration are your sole responsibility. By using this package, you acknowledge that you have read and understood this disclaimer and agree to use the package at your own risk.
 
 <!-- mcp-name: io.github.aws/mcp-proxy-for-aws -->
+<!-- mcp-name: io.github.aws/aws-mcp -->


### PR DESCRIPTION
## Summary
This change is to publish AWS MCP server in the official MCP registry https://registry.modelcontextprotocol.io/?q=aws 

It's visible in the registry already but the name shows as `io.github.aws/mcp-proxy-for-aws` which is confusing and ideally we want to show as `io.github.aws/aws-mcp`. 

Keep `io.github.aws/mcp-proxy-for-aws` for now during the transition period until we're confident to remove.  

### Changes

> Please provide a summary of what's being changed

Append a line in README

### User experience

> Please share what the user experience looks like before and after this change

Nothing would change. Invisible to customers.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ x] No

Please add details about how this change was tested.

- [ x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
