### PR TITLE
chore: Make integ test run also on synchronize and opened in pull requests

### DIFF
--- a/.github/workflows/python-integ.yml
+++ b/.github/workflows/python-integ.yml
@@ -4,7 +4,7 @@ name: Python Integration Tests
 on:
   pull_request:
     branches: main
-    types: ready_for_review
+    types: [opened, synchronize, ready_for_review]
   workflow_dispatch:
   push:
     branches: main


### PR DESCRIPTION
## Summary

### Changes
Integ tests are now also executed if code is pushed to a pr and not only on the initial ready for review event.

### User experience

* Developers won't have to move from draft to ready to trigger the integ tests
* Integ tests will have to pass before the PR can be merged.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
