### PR TITLE
chore: Disable integ tests on pull requests

### DIFF
--- a/.github/workflows/python-integ.yml
+++ b/.github/workflows/python-integ.yml
@@ -2,9 +2,6 @@ name: Python Integration Tests
 
 
 on:
-  pull_request:
-    branches: main
-    types: ready_for_review
   workflow_dispatch:
   push:
     branches: main


### PR DESCRIPTION
## Summary

### Changes

integration tests in pull requests don't work as they do not support secrets. 

### User experience

Before: Integ test in prs will never pass
After: No more integ tests in prs.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
