### PR TITLE
fix: Pin FastMCP version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ description = "MCP Proxy for AWS"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "fastmcp>=2.13.1",
+    "fastmcp (>=2.13.1,<2.14.1)",
     "boto3>=1.41.0",
     "botocore[crt]>=1.41.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2460,7 +2460,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.41.0" },
     { name = "botocore", extras = ["crt"], specifier = ">=1.41.0" },
-    { name = "fastmcp", specifier = ">=2.13.1" },
+    { name = "fastmcp", specifier = ">=2.13.1,<2.14.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

### Changes

FastMCP 2.14.1 introduced a backwards breaking change. For now pinning it to last known version.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
