### PR TITLE
fix: Use streamable_http_client to avoid DeprecationWarning

### DIFF
--- a/mcp_proxy_for_aws/client.py
+++ b/mcp_proxy_for_aws/client.py
@@ -18,7 +18,12 @@ from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStre
 from botocore.credentials import Credentials
 from contextlib import _AsyncGeneratorContextManager
 from datetime import timedelta
-from mcp.client.streamable_http import GetSessionIdCallback, streamablehttp_client
+from mcp.client.streamable_http import GetSessionIdCallback
+
+try:
+    from mcp.client.streamable_http import streamable_http_client
+except ImportError:
+    from mcp.client.streamable_http import streamablehttp_client as streamable_http_client
 from mcp.shared._httpx_utils import McpHttpClientFactory, create_mcp_http_client
 from mcp.shared.message import SessionMessage
 from mcp_proxy_for_aws.sigv4_helper import SigV4HTTPXAuth
@@ -114,7 +119,7 @@ def aws_iam_streamablehttp_client(
     auth = SigV4HTTPXAuth(creds, aws_service, region)
 
     # Return the streamable HTTP client context manager with AWS IAM authentication
-    return streamablehttp_client(
+    return streamable_http_client(
         url=endpoint,
         headers=headers,
         timeout=timeout,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -60,7 +60,7 @@ async def test_boto3_session_parameters(
     mock_read, mock_write, mock_get_session = mock_streams
 
     with patch('boto3.Session', return_value=mock_session) as mock_boto:
-        with patch('mcp_proxy_for_aws.client.streamablehttp_client') as mock_stream_client:
+        with patch('mcp_proxy_for_aws.client.streamable_http_client') as mock_stream_client:
             mock_stream_client.return_value.__aenter__ = AsyncMock(
                 return_value=(mock_read, mock_write, mock_get_session)
             )
@@ -94,7 +94,7 @@ async def test_sigv4_auth_is_created_and_used(mock_session, mock_streams, servic
 
     with patch('boto3.Session', return_value=mock_session):
         with patch('mcp_proxy_for_aws.client.SigV4HTTPXAuth') as mock_auth_cls:
-            with patch('mcp_proxy_for_aws.client.streamablehttp_client') as mock_stream_client:
+            with patch('mcp_proxy_for_aws.client.streamable_http_client') as mock_stream_client:
                 mock_auth = Mock()
                 mock_auth_cls.return_value = mock_auth
                 mock_stream_client.return_value.__aenter__ = AsyncMock(
@@ -131,13 +131,13 @@ async def test_sigv4_auth_is_created_and_used(mock_session, mock_streams, servic
 async def test_streamable_client_parameters(
     mock_session, mock_streams, headers, timeout_value, sse_value, terminate_value
 ):
-    """Test the correctness of streamablehttp_client parameters."""
+    """Test the correctness of streamable_http_client parameters."""
     # Verify that connection settings are forwarded as-is to the streamable HTTP client.
     # timedelta values are allowed and compared directly here.
     mock_read, mock_write, mock_get_session = mock_streams
 
     with patch('boto3.Session', return_value=mock_session):
-        with patch('mcp_proxy_for_aws.client.streamablehttp_client') as mock_stream_client:
+        with patch('mcp_proxy_for_aws.client.streamable_http_client') as mock_stream_client:
             mock_stream_client.return_value.__aenter__ = AsyncMock(
                 return_value=(mock_read, mock_write, mock_get_session)
             )
@@ -170,7 +170,7 @@ async def test_custom_httpx_client_factory_is_passed(mock_session, mock_streams)
     custom_factory = Mock()
 
     with patch('boto3.Session', return_value=mock_session):
-        with patch('mcp_proxy_for_aws.client.streamablehttp_client') as mock_stream_client:
+        with patch('mcp_proxy_for_aws.client.streamable_http_client') as mock_stream_client:
             mock_stream_client.return_value.__aenter__ = AsyncMock(
                 return_value=(mock_read, mock_write, mock_get_session)
             )
@@ -198,7 +198,7 @@ async def test_context_manager_cleanup(mock_session, mock_streams):
         cleanup_called = True
 
     with patch('boto3.Session', return_value=mock_session):
-        with patch('mcp_proxy_for_aws.client.streamablehttp_client') as mock_stream_client:
+        with patch('mcp_proxy_for_aws.client.streamable_http_client') as mock_stream_client:
             mock_stream_client.return_value.__aenter__ = AsyncMock(
                 return_value=(mock_read, mock_write, mock_get_session)
             )
@@ -220,7 +220,7 @@ async def test_credentials_parameter_with_region(mock_streams):
     creds = Credentials('test_key', 'test_secret', 'test_token')
 
     with patch('mcp_proxy_for_aws.client.SigV4HTTPXAuth') as mock_auth_cls:
-        with patch('mcp_proxy_for_aws.client.streamablehttp_client') as mock_stream_client:
+        with patch('mcp_proxy_for_aws.client.streamable_http_client') as mock_stream_client:
             mock_auth = Mock()
             mock_auth_cls.return_value = mock_auth
             mock_stream_client.return_value.__aenter__ = AsyncMock(
@@ -264,7 +264,7 @@ async def test_credentials_parameter_bypasses_boto3_session(mock_streams):
 
     with patch('boto3.Session') as mock_boto:
         with patch('mcp_proxy_for_aws.client.SigV4HTTPXAuth'):
-            with patch('mcp_proxy_for_aws.client.streamablehttp_client') as mock_stream_client:
+            with patch('mcp_proxy_for_aws.client.streamable_http_client') as mock_stream_client:
                 mock_stream_client.return_value.__aenter__ = AsyncMock(
                     return_value=(mock_read, mock_write, mock_get_session)
                 )


### PR DESCRIPTION
## Summary

- Updated the import in `client.py` to use the new `streamable_http_client` function name instead of the deprecated `streamablehttp_client`
- Added backward-compatible import that first tries the new function name, then falls back to the old one for older MCP SDK versions
- Updated unit tests to mock the new function name

## Details

The MCP Python SDK v1.24.0 (released Dec 12, 2025) introduced a new `streamable_http_client` function and deprecated the old `streamablehttp_client` (see [PR #1177](https://github.com/modelcontextprotocol/python-sdk/pull/1177)).

Users running with MCP SDK >= 1.24.0 see the following warning:
```
DeprecationWarning: Use streamable_http_client instead
```

This fix uses a try/except import pattern to:
1. Use the new `streamable_http_client` when available (MCP >= 1.24.0)
2. Fall back to `streamablehttp_client` for older versions (MCP < 1.24.0)

## Test plan

- [x] All existing unit tests pass (`uv run pytest tests/unit/test_client.py -v`)
- [x] Verified backward compatibility with MCP 1.20.0
- [x] Verified the new function exists in MCP 1.25.0 on PyPI

Fixes #128