### PR TITLE
fix: rename deprecated streamablehttp_client to streamable_http_client

### DIFF
--- a/mcp_proxy_for_aws/client.py
+++ b/mcp_proxy_for_aws/client.py
@@ -18,7 +18,7 @@ from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStre
 from botocore.credentials import Credentials
 from contextlib import _AsyncGeneratorContextManager
 from datetime import timedelta
-from mcp.client.streamable_http import GetSessionIdCallback, streamablehttp_client
+from mcp.client.streamable_http import GetSessionIdCallback, streamable_http_client
 from mcp.shared._httpx_utils import McpHttpClientFactory, create_mcp_http_client
 from mcp.shared.message import SessionMessage
 from mcp_proxy_for_aws.sigv4_helper import SigV4HTTPXAuth
@@ -114,7 +114,7 @@ def aws_iam_streamablehttp_client(
     auth = SigV4HTTPXAuth(creds, aws_service, region)
 
     # Return the streamable HTTP client context manager with AWS IAM authentication
-    return streamablehttp_client(
+    return streamable_http_client(
         url=endpoint,
         headers=headers,
         timeout=timeout,


### PR DESCRIPTION
## Summary
- Rename `streamablehttp_client` to `streamable_http_client` (with underscore) in `client.py`
- This resolves the DeprecationWarning from the MCP package

## Problem
When using this library, the following deprecation warning is shown:

```
DeprecationWarning: Use `streamable_http_client` instead.
```

The MCP package has renamed `streamablehttp_client` to `streamable_http_client`, and the old name is now deprecated.

## Changes
- Updated import statement in `mcp_proxy_for_aws/client.py`
- Updated function call in `aws_iam_streamablehttp_client()`