### PR TITLE
add workflow to automate dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for Dependabot PRs (patch and minor updates, excluding fastmcp)
+        if: |
+          !contains(steps.metadata.outputs.dependency-names, 'fastmcp') &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow to automatically merge Dependabot PRs for patch and minor version updates.

### Changes

- Add .github/workflows/dependabot-auto-merge.yml workflow that:
  - Triggers on pull requests from dependabot[bot]
  - Auto-merges patch and minor version updates using squash merge
  - Excludes fastmcp dependency from auto-merge (requires manual review)
  - Excludes major version updates from auto-merge (requires manual review)


Setup Required
For auto-merge to work, the following repository settings must be configured:

1. Enable auto-merge: Settings → General → Pull Requests → Check "Allow auto-merge"
2. Configure branch protection (Settings → Branches → Edit rule for main):
   - Enable "Require status checks to pass before merging"
   - Select required CI checks (e.g., build job)
   - Under "Allow specified actors to bypass required pull requests", add dependabot[bot]
Auto-merge Behavior


| Dependency | Update Type | Auto-merge |
|------------|-------------|------------|
| Any (except fastmcp) | Patch | Yes |
| Any (except fastmcp) | Minor | Yes |
| Any | Major | No |
| fastmcp | Any | No |



### User experience

Nothing will change.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
