### PR TITLE
test: Emit success and failure metrics for canaries to cloudwatch

### DIFF
--- a/.github/workflows/scheduled-integ-tests.yml
+++ b/.github/workflows/scheduled-integ-tests.yml
@@ -16,3 +16,36 @@ jobs:
       actions: read
     uses: ./.github/workflows/python-integ.yml
     secrets: inherit
+
+  publish-metrics:
+    needs: call-integ-tests
+    if: always()  # Run even if integration tests fail
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
+      - name: Publish CloudWatch Metrics
+        run: |
+          # Determine status value: 0 for success, 1 for failure
+          if [ "${{ needs.call-integ-tests.result }}" == "success" ]; then
+            STATUS_VALUE=0
+          else
+            STATUS_VALUE=1
+          fi
+
+          echo "Publishing metric with status: ${{ needs.call-integ-tests.result }} (value: $STATUS_VALUE)"
+
+          aws cloudwatch put-metric-data \
+            --namespace "GitHubActions/MCPProxy" \
+            --metric-name "IntegrationTestFailures" \
+            --dimensions WorkflowName=${{ github.workflow }},Repository=${{ github.repository }},Branch=${{ github.ref_name }} \
+            --value $STATUS_VALUE \
+            --unit Count \
+            --region us-east-1


### PR DESCRIPTION
## Summary                            

### Changes

This PR adds CloudWatch metrics emission to the scheduled integration tests workflow, enabling monitoring and alerting capabilities for the canary test runs.

**What's new:**
- Added a `publish-metrics` job that runs after integration tests complete
- Emits an `IntegrationTestStatus` metric to CloudWatch with:
  - Value: `0` for success, `1` for failure
  - Namespace: `GitHubActions/MCPProxy`
  - Dimensions: `WorkflowName`, `Repository`, `Branch`
- Job runs even if tests fail (using `if: always()`) to ensure metrics are always published

### User experience

**Before:**
- Scheduled integration tests run every 5 minutes but there's no centralized monitoring
- No way to set up CloudWatch alarms for test failures
- No historical tracking of test health trends

**After:**
- Test success/failure metrics are published to CloudWatch after each run
- Teams can create CloudWatch alarms to get notified of test failures
- Can visualize test health trends over time using CloudWatch dashboards
- Enables better observability for canary monitoring

**Note:** This requires additional setup:
1. IAM role with `cloudwatch:PutMetricData` permission must be created/updated
2. `AWS_ROLE_TO_ASSUME` GitHub secret must be configured with the role ARN

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

**Testing notes:**
- Workflow syntax has been validated
- Pre-commit hooks pass successfully
- Integration test job behavior remains unchanged
- Metrics publishing requires IAM permissions to be added separately (infrastructure change tracked separately)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.