### PR TITLE
Add environment specification for integ test metric emission

### DIFF
--- a/.github/workflows/scheduled-integ-tests.yml
+++ b/.github/workflows/scheduled-integ-tests.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    environment: Integ
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary

### Changes
Adding Env flag to populate secrets.

### User experience

None, but emitting metrics should start working.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [X] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
