### PR TITLE
Update scheduled-integ-tests.yml

### DIFF
--- a/.github/workflows/scheduled-integ-tests.yml
+++ b/.github/workflows/scheduled-integ-tests.yml
@@ -46,7 +46,7 @@ jobs:
           aws cloudwatch put-metric-data \
             --namespace "GitHubActions/MCPProxy" \
             --metric-name "IntegrationTestFailures" \
-            --dimensions WorkflowName=${{ github.workflow }},Repository=${{ github.repository }},Branch=${{ github.ref_name }} \
+            --dimensions WorkflowName=IntegrationCanary \
             --value $STATUS_VALUE \
             --unit Count \
             --region us-east-1


### PR DESCRIPTION
## Summary

### Changes

The actual metric emission is failing due to the dimensions being off, simplifying those for now. 
I tested the command locally with:
```
aws cloudwatch put-metric-data \
--namespace "GitHubActions/MCPProxy" \
--metric-name "IntegrationTestFailures" \
--dimensions WorkflowName=Test \
--value 1 \
--unit Count \
--region us-east-1
``` 

And observed the emitted metric in CloudWatch.
### User experience

No change.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
