### PR TITLE
docs: Update Docker usage instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,20 +70,7 @@ uv run mcp_proxy_for_aws/server.py <SigV4 MCP endpoint URL>
 ```
 
 #### Using Docker
-
-Docker images are published to the [public AWS ECR registry](https://gallery.ecr.aws/mcp-proxy-for-aws/mcp-proxy-for-aws).
-
-You can use the pre-built image:
-
-```bash
-# Pull the latest image
-docker pull public.ecr.aws/mcp-proxy-for-aws/mcp-proxy-for-aws:latest
-
-# Or pull a specific version
-docker pull public.ecr.aws/mcp-proxy-for-aws/mcp-proxy-for-aws:1.1.5
-```
-
-Or build the image locally:
+Build the image locally:
 
 ```bash
 # Build the Docker image
@@ -165,28 +152,7 @@ Add the following configuration to your MCP client config file (e.g., for Kiro C
 
 #### Using Docker
 
-Using the pre-built public ECR image:
-
-```json
-{
-  "mcpServers": {
-    "<mcp server name>": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "--volume",
-        "/full/path/to/.aws:/app/.aws:ro",
-        "public.ecr.aws/mcp-proxy-for-aws/mcp-proxy-for-aws:latest",
-        "<SigV4 MCP endpoint URL>"
-      ],
-      "env": {}
-    }
-  }
-}
-```
-
-Or using a locally built image:
+using a locally built image:
 
 ```json
 {


### PR DESCRIPTION
Removed instructions for using pre-built Docker images and updated to focus on using a locally built image.

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
