### PR TITLE
fix: replace failing integ test

### DIFF
--- a/tests/integ/test_aws_mcp_server_happy_path.py
+++ b/tests/integ/test_aws_mcp_server_happy_path.py
@@ -101,7 +101,7 @@ def verify_json_response(response: CallToolResult):
             'aws___get_regional_availability',
             {'resource_type': 'cfn', 'region': 'us-east-1'},
         ),
-        ('aws___call_aws', {'cli_command': 'aws s3 ls', 'max_results': 10}),
+        ('aws___call_aws', {'cli_command': 'aws lambda list-functions', 'max_results': 10}),
     ],
     ids=[
         'list_regions',
@@ -110,7 +110,7 @@ def verify_json_response(response: CallToolResult):
         'recommend',
         'read_documentation',
         'get_regional_availability',
-        'call_aws',
+        'list_lambda_functions',
     ],
 )
 @pytest.mark.asyncio(loop_scope='module')


### PR DESCRIPTION
## Summary                            

### Changes

This PR makes the following changes:

1. **Fix integration test IAM permission issues**: Removed the failing `aws s3 ls` integration test that required `s3:ListAllMyBuckets` permission (which the test role doesn't have) and replaced it with `aws
lambda list-functions` test that uses standard read-only permissions.

### User experience

**Before:**
- Tests failed frequently due to missing `s3:ListAllMyBuckets` permission
- CloudWatch alarms triggered for integration test failures every 5 minutes

**After:**
- Tests use Lambda list functions instead of S3, which aligns with standard read-only permissions
- More reliable test execution with consistent AWS environment
- Better integration with AWS services and future scalability for canary testing

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [x] If the feature is a new use case, is it necessary to add a new integration test case? (Replaced S3 test with Lambda test)

**Testing Notes:**
- The Lambda test case has been added and follows the same pattern as the removed S3 test
## Acknowledgment

By submitting thi