### PR TITLE
Add 1 second sleep between Integ tests to prevent throttling

### DIFF
--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -14,9 +14,9 @@
 
 import logging
 import os
-import time
 import pytest
 import pytest_asyncio
+import time
 from .mcp.simple_mcp_client import build_mcp_client
 from typing import TypedDict
 
@@ -122,5 +122,5 @@ async def aws_mcp_client():
 @pytest.fixture(autouse=True)
 def sleep_between_tests():
     """Sleep for 1 second before each test to avoid rate limiting."""
-    print("Sleeping for 1 second to avoid rate limiting")
+    print('Sleeping for 1 second to avoid rate limiting')
     time.sleep(1)


### PR DESCRIPTION
## Summary

### Changes

Adding a 1 second sleep between tests, to prevent throttling in our Integ tests.

For example, one of our tests failed today due to throttling. See [[integ run](https://github.com/aws/mcp-proxy-for-aws/actions/runs/22444409797/job/64994874893)]

```
2026-02-26 13:35:31 | WARNING | mcp_proxy_for_aws.sigv4_helper | HTTP 429 Error Details: {'jsonrpc': '2.0', 'id': 10, 'result': None, 'error': {'code': -32004, 'message': 'Too many requests. Please try again later.'}}
2026-02-26 13:35:31 | DEBUG | mcp_proxy_for_aws.sigv4_helper | === Outgoing Request ===
2026-02-26 13:35:31 | DEBUG | mcp_proxy_for_aws.sigv4_helper | URL: https://aws-mcp.us-east-1.api.aws/mcp
2026-02-26 13:35:31 | DEBUG | mcp_proxy_for_aws.sigv4_helper | Method: DELETE
2026-02-26 13:35:31 | DEBUG | mcp_proxy_for_aws.sigv4_helper | Signing request with credentials for access key: ASIA...PJOZ
2026-02-26 13:35:31 | DEBUG | mcp_proxy_for_aws.sigv4_helper | Request headers after signing: {'connection': 'keep-alive', 'host': 'aws-mcp.us-east-1.api.aws', 'accept-encoding': 'gzip, deflate', 'user-agent': 'python-httpx/0.28.1', 'accept': 'application/json, text/event-stream', 'content-type': 'application/json', 'mcp-session-id': '1a7c225d-bb3b-4666-9f1a-6e499d8d4f4c', 'mcp-protocol-version': '2025-06-18', 'content-length': '0', 'x-amz-date': '[REDACTED]', 'x-amz-security-token': '[REDACTED]', 'authorization': '[REDACTED]'}
FAILED
```

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [X] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
