### PR TITLE
feat(auth): add CredentialRefresher for automatic session renewal

### DIFF
--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -24,7 +24,8 @@ from botocore.credentials import Credentials
 from functools import partial
 from httpx import __version__ as httpx_version
 from mcp_proxy_for_aws import __version__
-from typing import Any, Dict, Generator, Optional
+from pathlib import Path
+from typing import Any, Dict, Generator, Optional, Tuple
 
 
 logger = logging.getLogger(__name__)
@@ -119,12 +120,53 @@ def create_aws_session(profile: Optional[str] = None) -> boto3.Session:
     return session
 
 
+def _get_file_mtimes() -> Tuple[Optional[float], Optional[float]]:
+    """Get modification times of ~/.aws/config and ~/.aws/credentials."""
+    aws_dir = Path.home() / '.aws'
+    results: list[Optional[float]] = []
+    for path in (aws_dir / 'config', aws_dir / 'credentials'):
+        try:
+            results.append(path.stat().st_mtime)
+        except OSError:
+            results.append(None)
+    return (results[0], results[1])
+
+
+class CredentialRefresher:
+    """Refreshes the boto3 session when AWS credential files change on disk.
+
+    Monitors ~/.aws/config and ~/.aws/credentials modification times.
+    When files change, creates a new boto3 session to pick up updated credentials.
+    """
+
+    def __init__(self, profile: Optional[str] = None) -> None:
+        """Initialize with an AWS profile."""
+        self._profile = profile
+        self._session = create_aws_session(profile)
+        self._file_mtimes = _get_file_mtimes()
+
+    def get_session(self) -> boto3.Session:
+        """Return the current boto3 session, refreshing when config files change."""
+        current_mtimes = _get_file_mtimes()
+        if current_mtimes == self._file_mtimes:
+            return self._session
+
+        logger.debug('AWS config file change detected, refreshing session')
+        self._file_mtimes = current_mtimes
+
+        try:
+            self._session = create_aws_session(self._profile)
+        except ValueError:
+            logger.warning('Failed to create fresh AWS session, using cached session')
+
+        return self._session
+
+
 def create_sigv4_client(
     service: str,
     region: str,
+    credential_refresher: CredentialRefresher,
     timeout: Optional[httpx.Timeout] = None,
-    profile: Optional[str] = None,
-    session: Optional[boto3.Session] = None,
     headers: Optional[Dict[str, str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
     **kwargs: Any,
@@ -133,9 +175,8 @@ def create_sigv4_client(
 
     Args:
         service: AWS service name for SigV4 signing
-        profile: AWS profile to use (optional, only used if session is not provided)
-        session: AWS boto3 session to use (optional, takes precedence over profile)
-        region: AWS region (optional, defaults to AWS_REGION env var or us-east-1)
+        region: AWS region for SigV4 signing
+        credential_refresher: Refresher that provides up-to-date boto3 sessions
         timeout: Timeout configuration for the HTTP client
         headers: Headers to include in requests
         metadata: Metadata to inject into MCP _meta field
@@ -144,10 +185,6 @@ def create_sigv4_client(
     Returns:
         httpx.AsyncClient with SigV4 authentication
     """
-    # Create or use provided AWS session
-    if session is None:
-        session = create_aws_session(profile)
-
     # Create a copy of kwargs to avoid modifying the passed dict
     client_kwargs = {
         'follow_redirects': True,
@@ -179,7 +216,7 @@ def create_sigv4_client(
             'response': [_handle_error_response],
             'request': [
                 partial(_inject_metadata_hook, metadata or {}),
-                partial(_sign_request_hook, region, service, session),
+                partial(_sign_request_hook, region, service, credential_refresher),
             ],
         },
     )
@@ -238,31 +275,28 @@ async def _handle_error_response(response: httpx.Response) -> None:
 async def _sign_request_hook(
     region: str,
     service: str,
-    session: boto3.Session,
+    credential_refresher: CredentialRefresher,
     request: httpx.Request,
 ) -> None:
     """Request hook to sign HTTP requests with AWS SigV4.
 
     This hook signs the request with AWS SigV4 credentials and adds signature headers.
+    Uses the credential refresher to pick up changes to ~/.aws/credentials or ~/.aws/config.
 
     This should be the last hook called to ensure the signature includes any modifications.
 
     Args:
         region: AWS region for SigV4 signing
         service: AWS service name for SigV4 signing
-        session: AWS boto3 session to use for credentials
+        credential_refresher: Refresher that provides up-to-date boto3 sessions
         request: The HTTP request object to sign (modified in-place)
     """
     # Set Content-Length for signing
     request.headers['Content-Length'] = str(len(request.content))
 
-    # Get AWS credentials from the session
+    # Get AWS credentials from the current session (refreshed if config files changed)
+    session = credential_refresher.get_session()
     credentials = session.get_credentials()
-    logger.debug(
-        'Signing request with credentials for access key: %s...%s',
-        credentials.access_key[:4],
-        credentials.access_key[-4:],
-    )
 
     # Create SigV4 auth and use its signing logic
     auth = SigV4HTTPXAuth(credentials, service, region)

--- a/mcp_proxy_for_aws/utils.py
+++ b/mcp_proxy_for_aws/utils.py
@@ -19,7 +19,7 @@ import httpx
 import logging
 import os
 from fastmcp.client.transports import StreamableHttpTransport
-from mcp_proxy_for_aws.sigv4_helper import create_aws_session, create_sigv4_client
+from mcp_proxy_for_aws.sigv4_helper import CredentialRefresher, create_sigv4_client
 from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -88,9 +88,9 @@ def create_transport_with_sigv4(
     Returns:
         StreamableHttpTransport instance with SigV4 authentication
     """
-    # Create AWS session once and reuse it for all httpx clients
-    logger.debug('Creating AWS session with profile: %s', profile)
-    session = create_aws_session(profile)
+    # Create credential refresher that auto-detects config file changes
+    logger.debug('Creating credential refresher with profile: %s', profile)
+    credential_refresher = CredentialRefresher(profile)
 
     def client_factory(
         headers: Optional[Dict[str, str]] = None,
@@ -100,7 +100,7 @@ def create_transport_with_sigv4(
     ) -> httpx.AsyncClient:
         return create_sigv4_client(
             service=service,
-            session=session,
+            credential_refresher=credential_refresher,
             region=region,
             headers=headers,
             timeout=custom_timeout,

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -22,7 +22,7 @@ from mcp_proxy_for_aws.server import (
     parse_args,
     run_proxy,
 )
-from mcp_proxy_for_aws.sigv4_helper import create_sigv4_client
+from mcp_proxy_for_aws.sigv4_helper import CredentialRefresher, create_sigv4_client
 from mcp_proxy_for_aws.utils import determine_service_name
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -403,26 +403,17 @@ class TestServer:
             result = determine_service_name(endpoint)
             assert result == expected_service
 
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('mcp_proxy_for_aws.sigv4_helper.httpx.AsyncClient')
-    def test_create_sigv4_client(self, mock_async_client, mock_create_session):
-        """Test creating SigV4 authenticated client with request hooks.
-
-        Note: Session creation and signing now happens in sign_request_hook,
-        not during client creation.
-        """
-        # Mock session creation
-        mock_session = Mock()
-        mock_session.get_credentials.return_value = Mock(access_key='test-key')
-        mock_create_session.return_value = mock_session
+    def test_create_sigv4_client(self, mock_async_client):
+        """Test creating SigV4 authenticated client with request hooks."""
+        mock_refresher = Mock(spec=CredentialRefresher)
 
         # Act
-        create_sigv4_client(service='test-service', region='us-west-2', profile='test-profile')
+        create_sigv4_client(
+            service='test-service', region='us-west-2', credential_refresher=mock_refresher
+        )
 
         # Assert
-        # Verify session was created with profile
-        mock_create_session.assert_called_once_with('test-profile')
-        # Verify AsyncClient was called (signing happens via hooks)
         assert mock_async_client.call_count == 1
         call_args = mock_async_client.call_args
         # Verify hooks are registered
@@ -431,21 +422,6 @@ class TestServer:
         assert 'response' in call_args[1]['event_hooks']
         # Should have metadata injection + sign hooks
         assert len(call_args[1]['event_hooks']['request']) == 2
-
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
-    def test_create_sigv4_client_no_credentials(self, mock_create_session):
-        """Test that credential check happens in sign_request_hook, not during client creation.
-
-        Note: With the refactoring, client creation no longer validates credentials.
-        Credential validation now happens in sign_request_hook when the request is signed.
-        """
-        mock_session = Mock()
-        mock_create_session.return_value = mock_session
-
-        # Client creation should succeed even without credentials
-        # (credentials are checked when signing happens)
-        client = create_sigv4_client(service='test-service', region='test-region')
-        assert client is not None
 
     def test_main_module_execution(self):
         """Test that main is called when module is executed directly."""

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -20,6 +20,7 @@ from httpx import __version__ as httpx_version
 from mcp_proxy_for_aws import __version__
 from mcp_proxy_for_aws.sigv4_helper import (
     SENSITIVE_HEADERS,
+    CredentialRefresher,
     SigV4HTTPXAuth,
     _sanitize_headers,
     create_aws_session,
@@ -123,17 +124,17 @@ class TestCreateAwsSession:
 class TestCreateSigv4Client:
     """Test cases for the create_sigv4_client function."""
 
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('httpx.AsyncClient')
-    def test_create_sigv4_client_default(self, mock_client_class, mock_create_session):
+    def test_create_sigv4_client_default(self, mock_client_class):
         """Test creating SigV4 client with default parameters."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        mock_session = Mock()
-        mock_create_session.return_value = mock_session
+        mock_refresher = Mock(spec=CredentialRefresher)
 
         # Test client creation
-        result = create_sigv4_client(service='test-service', region='test-region')
+        result = create_sigv4_client(
+            service='test-service', region='test-region', credential_refresher=mock_refresher
+        )
 
         # Check that AsyncClient was called with correct parameters
         call_args = mock_client_class.call_args
@@ -148,19 +149,20 @@ class TestCreateSigv4Client:
         assert call_args[1]['headers']['User-Agent'] == expected_user_agent
         assert result == mock_client
 
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('httpx.AsyncClient')
-    def test_create_sigv4_client_with_custom_headers(self, mock_client_class, mock_create_session):
+    def test_create_sigv4_client_with_custom_headers(self, mock_client_class):
         """Test creating SigV4 client with custom headers."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        mock_session = Mock()
-        mock_create_session.return_value = mock_session
+        mock_refresher = Mock(spec=CredentialRefresher)
 
         # Test client creation with custom headers
         custom_headers = {'Custom-Header': 'custom-value'}
         result = create_sigv4_client(
-            service='test-service', region='test-region', headers=custom_headers
+            service='test-service',
+            region='test-region',
+            credential_refresher=mock_refresher,
+            headers=custom_headers,
         )
 
         # Verify client was created with merged headers
@@ -173,43 +175,33 @@ class TestCreateSigv4Client:
         assert call_args[1]['headers'] == expected_headers
         assert result == mock_client
 
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('httpx.AsyncClient')
-    def test_create_sigv4_client_with_custom_service_and_region(
-        self, mock_client_class, mock_create_session
-    ):
+    def test_create_sigv4_client_with_custom_service_and_region(self, mock_client_class):
         """Test creating SigV4 client with custom service and region."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-
-        # Mock session creation
-        mock_session = Mock()
-        mock_session.get_credentials.return_value = Mock(access_key='test-key')
-        mock_create_session.return_value = mock_session
+        mock_refresher = Mock(spec=CredentialRefresher)
 
         # Test client creation with custom parameters
         result = create_sigv4_client(
-            service='custom-service', profile='test-profile', region='us-east-1'
+            service='custom-service', region='us-east-1', credential_refresher=mock_refresher
         )
 
-        # Verify session was created with profile
-        mock_create_session.assert_called_once_with('test-profile')
         # Verify client was created
         assert result == mock_client
 
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('httpx.AsyncClient')
-    def test_create_sigv4_client_with_kwargs(self, mock_client_class, mock_create_session):
+    def test_create_sigv4_client_with_kwargs(self, mock_client_class):
         """Test creating SigV4 client with additional kwargs."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        mock_session = Mock()
-        mock_create_session.return_value = mock_session
+        mock_refresher = Mock(spec=CredentialRefresher)
 
         # Test client creation with additional kwargs
         result = create_sigv4_client(
             service='test-service',
             region='test-region',
+            credential_refresher=mock_refresher,
             verify=False,
             proxies={'http': 'http://proxy:8080'},
         )
@@ -220,19 +212,12 @@ class TestCreateSigv4Client:
         assert call_args[1]['proxies'] == {'http': 'http://proxy:8080'}
         assert result == mock_client
 
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('httpx.AsyncClient')
-    def test_create_sigv4_client_with_prompt_context(self, mock_client_class, mock_create_session):
-        """Test creating SigV4 client when prompts exist in the system context.
-
-        This test simulates the scenario where the sigv4_helper is used in a context
-        where MCP prompts are present, ensuring the client is properly configured
-        to handle requests that might include prompt-related content or headers.
-        """
+    def test_create_sigv4_client_with_prompt_context(self, mock_client_class):
+        """Test creating SigV4 client with prompt context headers."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        mock_session = Mock()
-        mock_create_session.return_value = mock_session
+        mock_refresher = Mock(spec=CredentialRefresher)
 
         # Test client creation with headers that might be used when prompts exist
         prompt_context_headers = {
@@ -241,7 +226,10 @@ class TestCreateSigv4Client:
         }
 
         result = create_sigv4_client(
-            service='test-service', headers=prompt_context_headers, region='us-west-2'
+            service='test-service',
+            region='us-west-2',
+            credential_refresher=mock_refresher,
+            headers=prompt_context_headers,
         )
 
         # Check that AsyncClient was called with correct parameters including prompt headers
@@ -336,3 +324,87 @@ class TestSanitizeHeaders:
         assert 'authorization' in SENSITIVE_HEADERS
         assert 'x-amz-security-token' in SENSITIVE_HEADERS
         assert 'x-amz-date' in SENSITIVE_HEADERS
+
+
+class TestCredentialRefresher:
+    """Test cases for the CredentialRefresher class."""
+
+    def _make_session_mock(self):
+        """Helper to create a mock boto3 session."""
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = Mock()
+        return mock_session
+
+    @patch('mcp_proxy_for_aws.sigv4_helper._get_file_mtimes', return_value=(1.0, 1.0))
+    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
+    def test_initial_session_creation(self, mock_create_session, _mock_mtimes):
+        """Test that CredentialRefresher creates a session on init."""
+        mock_session = self._make_session_mock()
+        mock_create_session.return_value = mock_session
+
+        refresher = CredentialRefresher(profile='test-profile')
+
+        mock_create_session.assert_called_once_with('test-profile')
+        assert refresher.get_session() is mock_session
+
+    @patch('mcp_proxy_for_aws.sigv4_helper._get_file_mtimes', return_value=(1.0, 1.0))
+    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
+    def test_returns_cached_session_when_files_unchanged(self, mock_create_session, _mock_mtimes):
+        """Test that get_session returns cached session when config files haven't changed."""
+        mock_session = self._make_session_mock()
+        mock_create_session.return_value = mock_session
+
+        refresher = CredentialRefresher()
+        result1 = refresher.get_session()
+        result2 = refresher.get_session()
+
+        assert result1 is result2
+        mock_create_session.assert_called_once()
+
+    @patch('mcp_proxy_for_aws.sigv4_helper._get_file_mtimes')
+    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
+    def test_creates_fresh_session_when_files_change(self, mock_create_session, mock_mtimes):
+        """Test that get_session creates a fresh session when config files change."""
+        session1 = self._make_session_mock()
+        session2 = self._make_session_mock()
+        mock_create_session.side_effect = [session1, session2]
+        mock_mtimes.side_effect = [(1.0, 1.0), (2.0, 1.0)]
+
+        refresher = CredentialRefresher()
+        result = refresher.get_session()
+
+        assert result is session2
+        assert mock_create_session.call_count == 2
+
+    @patch('mcp_proxy_for_aws.sigv4_helper._get_file_mtimes')
+    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
+    def test_falls_back_to_cached_session_on_error(self, mock_create_session, mock_mtimes):
+        """Test that get_session falls back to cached session if fresh session fails."""
+        original_session = self._make_session_mock()
+        mock_create_session.side_effect = [original_session, ValueError('no creds')]
+        mock_mtimes.side_effect = [(1.0, 1.0), (2.0, 1.0)]
+
+        refresher = CredentialRefresher()
+        result = refresher.get_session()
+
+        assert result is original_session
+
+    @patch('mcp_proxy_for_aws.sigv4_helper._get_file_mtimes')
+    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
+    def test_multiple_file_changes(self, mock_create_session, mock_mtimes):
+        """Test detecting multiple sequential file changes."""
+        sessions = [self._make_session_mock() for _ in range(3)]
+        mock_create_session.side_effect = sessions
+        mock_mtimes.side_effect = [
+            (1.0, 1.0),  # init
+            (2.0, 1.0),  # first get_session
+            (3.0, 1.0),  # second get_session
+        ]
+
+        refresher = CredentialRefresher()
+
+        result1 = refresher.get_session()
+        assert result1 is sessions[1]
+
+        result2 = refresher.get_session()
+        assert result2 is sessions[2]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -113,18 +113,18 @@ class TestValidateEndpointUrl:
 
 
 class TestCreateTransportWithSigv4:
-    """Test cases for create_transport_with_sigv4 function (line 129)."""
+    """Test cases for create_transport_with_sigv4 function."""
 
-    @patch('mcp_proxy_for_aws.utils.create_aws_session')
+    @patch('mcp_proxy_for_aws.utils.CredentialRefresher')
     @patch('mcp_proxy_for_aws.utils.create_sigv4_client')
-    def test_create_transport_with_sigv4(self, mock_create_sigv4_client, mock_create_session):
+    def test_create_transport_with_sigv4(self, mock_create_sigv4_client, mock_refresher_class):
         """Test creating StreamableHttpTransport with SigV4 authentication."""
         from httpx import Timeout
 
         mock_client = MagicMock()
         mock_create_sigv4_client.return_value = mock_client
-        mock_session = MagicMock()
-        mock_create_session.return_value = mock_session
+        mock_refresher = MagicMock()
+        mock_refresher_class.return_value = mock_refresher
 
         url = 'https://test-service.us-west-2.api.aws/mcp'
         service = 'test-service'
@@ -137,15 +137,14 @@ class TestCreateTransportWithSigv4:
             url, service, region, metadata, custom_timeout, profile
         )
 
-        # Verify session was created with profile
-        mock_create_session.assert_called_once_with(profile)
+        # Verify credential refresher was created with profile
+        mock_refresher_class.assert_called_once_with(profile)
 
         # Verify result is StreamableHttpTransport
         assert isinstance(result, StreamableHttpTransport)
         assert result.url == url
 
         # Test that the httpx_client_factory calls create_sigv4_client correctly
-        # We need to access the factory through the transport's internal structure
         if hasattr(result, 'httpx_client_factory') and result.httpx_client_factory:
             factory = result.httpx_client_factory
             test_kwargs = {'headers': {'test': 'header'}, 'timeout': Timeout(30.0), 'auth': None}
@@ -153,7 +152,7 @@ class TestCreateTransportWithSigv4:
 
             mock_create_sigv4_client.assert_called_once_with(
                 service=service,
-                session=mock_session,
+                credential_refresher=mock_refresher,
                 region=region,
                 headers={'test': 'header'},
                 timeout=custom_timeout,
@@ -161,19 +160,18 @@ class TestCreateTransportWithSigv4:
                 metadata=metadata,
             )
         else:
-            # If we can't access the factory directly, just verify the transport was created
             assert result is not None
 
-    @patch('mcp_proxy_for_aws.utils.create_aws_session')
+    @patch('mcp_proxy_for_aws.utils.CredentialRefresher')
     @patch('mcp_proxy_for_aws.utils.create_sigv4_client')
     def test_create_transport_with_sigv4_no_profile(
-        self, mock_create_sigv4_client, mock_create_session
+        self, mock_create_sigv4_client, mock_refresher_class
     ):
         """Test creating transport without profile."""
         from httpx import Timeout
 
-        mock_session = MagicMock()
-        mock_create_session.return_value = mock_session
+        mock_refresher = MagicMock()
+        mock_refresher_class.return_value = mock_refresher
 
         url = 'https://test-service.us-west-2.api.aws/mcp'
         service = 'test-service'
@@ -183,18 +181,17 @@ class TestCreateTransportWithSigv4:
 
         result = create_transport_with_sigv4(url, service, region, metadata, custom_timeout)
 
-        # Verify session was created without profile
-        mock_create_session.assert_called_once_with(None)
+        # Verify credential refresher was created without profile
+        mock_refresher_class.assert_called_once_with(None)
 
         # Test that the httpx_client_factory calls create_sigv4_client correctly
-        # We need to access the factory through the transport's internal structure
         if hasattr(result, 'httpx_client_factory') and result.httpx_client_factory:
             factory = result.httpx_client_factory
             factory(headers=None, timeout=None, auth=None)
 
             mock_create_sigv4_client.assert_called_once_with(
                 service=service,
-                session=mock_session,
+                credential_refresher=mock_refresher,
                 region=region,
                 headers=None,
                 timeout=custom_timeout,
@@ -202,19 +199,18 @@ class TestCreateTransportWithSigv4:
                 metadata=metadata,
             )
         else:
-            # If we can't access the factory directly, just verify the transport was created
             assert result is not None
 
-    @patch('mcp_proxy_for_aws.utils.create_aws_session')
+    @patch('mcp_proxy_for_aws.utils.CredentialRefresher')
     @patch('mcp_proxy_for_aws.utils.create_sigv4_client')
     def test_create_transport_with_sigv4_kwargs_passthrough(
-        self, mock_create_sigv4_client, mock_create_session
+        self, mock_create_sigv4_client, mock_refresher_class
     ):
         """Test that kwargs are passed through to create_sigv4_client."""
         from httpx import Timeout
 
-        mock_session = MagicMock()
-        mock_create_session.return_value = mock_session
+        mock_refresher = MagicMock()
+        mock_refresher_class.return_value = mock_refresher
 
         url = 'https://test-service.us-west-2.api.aws/mcp'
         service = 'test-service'
@@ -231,7 +227,7 @@ class TestCreateTransportWithSigv4:
 
         mock_create_sigv4_client.assert_called_once_with(
             service=service,
-            session=mock_session,
+            credential_refresher=mock_refresher,
             region=region,
             headers=None,
             timeout=custom_timeout,


### PR DESCRIPTION
## Summary
- Add `CredentialRefresher` class that monitors `~/.aws/config` and `~/.aws/credentials` file modification times and automatically creates a fresh boto3 session when changes are detected
- Remove logging of AWS access key material from `_sign_request_hook`
- Update `create_sigv4_client` to accept a `CredentialRefresher` instead of a raw session/profile

## Test plan
- [ ] Unit tests for `CredentialRefresher` (cached session reuse, refresh on file change, fallback on error, multiple sequential changes)
- [ ] Updated tests for `create_sigv4_client` and `create_transport_with_sigv4` to use the new `CredentialRefresher`
- [ ] `uv run ruff check .` passes
- [ ] `uv run pyright` passes (no new errors)