### PR TITLE
fix(auth): remove sensitive credential logging

### DIFF
--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -266,11 +266,6 @@ async def _sign_request_hook(
 
     # Get AWS credentials from the session
     credentials = session.get_credentials()
-    logger.debug(
-        'Signing request with credentials for access key: %s...%s',
-        credentials.access_key[:4],
-        credentials.access_key[-4:],
-    )
 
     # Create SigV4 auth and use its signing logic
     auth = SigV4HTTPXAuth(credentials, service, region)


### PR DESCRIPTION
## Summary
- Remove `logger.debug` call in `_sign_request_hook` that logged partial AWS access key IDs