### PR TITLE
fix: refresh stale credentials on auth failure without restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,8 +353,10 @@ For long-running sessions, consider using long-lived credentials:
 - Use an AWS profile via `--profile`
 - Use IAM Identity Center and run `aws sso login` before starting the proxy
 
+If your credentials do expire during a session, the proxy will automatically detect the auth failure and pick up refreshed credentials on the next request — no restart required. Simply refresh your credentials (e.g., `aws sso login`) and retry.
+
 ### Client hangs on tool calls
-If your MCP client hangs waiting for a tool call response (e.g., due to expired credentials or an unresponsive endpoint), use `--tool-timeout` to set a maximum duration in seconds for each tool call. When the timeout is exceeded, the proxy returns a graceful error to the agent instead of hanging indefinitely.
+If your MCP client hangs waiting for a tool call response (e.g., due to an unresponsive endpoint), use `--tool-timeout` to set a maximum duration in seconds for each tool call. When the timeout is exceeded, the proxy returns a graceful error to the agent instead of hanging indefinitely.
 
 ## Development & Contributing
 

--- a/mcp_proxy_for_aws/middleware/tool_error_middleware.py
+++ b/mcp_proxy_for_aws/middleware/tool_error_middleware.py
@@ -62,17 +62,32 @@ class ToolErrorMiddleware(Middleware):
             logger.error('Tool call %r failed: %s.', tool_name, e)
             message = f'Tool call {tool_name!r} failed: {e}. Please retry.'
             if self._is_credential_error(e):
-                message += (
-                    ' This may be caused by expired or invalid AWS credentials.'
-                    ' Consider using long-lived credentials such as an AWS profile'
-                    ' (--profile) or IAM Identity Center (aws sso login).'
+                message = (
+                    f'Tool call {tool_name!r} failed due to expired or invalid AWS credentials.'
+                    ' Please refresh your credentials and retry.'
+                    ' The proxy will automatically use the new credentials on the next request.'
                 )
             raise ToolError(message) from e
 
     @staticmethod
     def _is_credential_error(error: Exception) -> bool:
         """Check if the error is likely caused by expired or invalid credentials."""
-        return isinstance(error, httpx.HTTPStatusError) and error.response.status_code in (
-            401,
-            403,
-        )
+        # Walk the exception chain — the 401/403 may be wrapped
+        current: BaseException | None = error
+        while current is not None:
+            if isinstance(current, httpx.HTTPStatusError) and current.response.status_code in (
+                401,
+                403,
+            ):
+                return True
+            current = current.__cause__ if current.__cause__ else current.__context__
+            # Avoid infinite loops on self-referencing chains
+            if current is error:
+                break
+
+        # "Unknown tool" after a failed reconnect is almost always a credential issue
+        error_str = str(error)
+        if 'Unknown tool' in error_str or 'Unauthorized' in error_str:
+            return True
+
+        return False

--- a/mcp_proxy_for_aws/middleware/tool_error_middleware.py
+++ b/mcp_proxy_for_aws/middleware/tool_error_middleware.py
@@ -71,8 +71,12 @@ class ToolErrorMiddleware(Middleware):
 
     @staticmethod
     def _is_credential_error(error: Exception) -> bool:
-        """Check if the error is likely caused by expired or invalid credentials."""
-        # Walk the exception chain — the 401/403 may be wrapped
+        """Check if the error is likely caused by expired or invalid credentials.
+
+        Walks the exception chain (__cause__/__context__) because the
+        HTTPStatusError may be wrapped.  isinstance already respects the
+        MRO, so subclasses are caught too.
+        """
         current: BaseException | None = error
         while current is not None:
             if isinstance(current, httpx.HTTPStatusError) and current.response.status_code in (
@@ -80,6 +84,5 @@ class ToolErrorMiddleware(Middleware):
                 403,
             ):
                 return True
-            current = current.__cause__ if current.__cause__ else current.__context__
-
+            current = current.__cause__ or current.__context__
         return False

--- a/mcp_proxy_for_aws/middleware/tool_error_middleware.py
+++ b/mcp_proxy_for_aws/middleware/tool_error_middleware.py
@@ -81,13 +81,5 @@ class ToolErrorMiddleware(Middleware):
             ):
                 return True
             current = current.__cause__ if current.__cause__ else current.__context__
-            # Avoid infinite loops on self-referencing chains
-            if current is error:
-                break
-
-        # "Unknown tool" after a failed reconnect is almost always a credential issue
-        error_str = str(error)
-        if 'Unknown tool' in error_str or 'Unauthorized' in error_str:
-            return True
 
         return False

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -140,12 +140,12 @@ class SessionHolder:
         """Create a fresh session if a previous request got an auth error."""
         if not self._needs_refresh:
             return
-        self._needs_refresh = False
         logger.info('Refreshing AWS session to pick up new credentials')
         try:
             self.session = create_aws_session(self._profile)
+            self._needs_refresh = False
         except ValueError:
-            logger.warning('Failed to create fresh AWS session, keeping current session')
+            logger.warning('Failed to create fresh AWS session, keeping current session', exc_info=True)
 
 
 def create_sigv4_client(

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -145,7 +145,7 @@ class SessionHolder:
         try:
             self.session = create_aws_session(self._profile)
             self._needs_refresh = False
-        except ValueError:
+        except Exception:
             logger.warning(
                 'Failed to create fresh AWS session, keeping current session', exc_info=True
             )
@@ -302,11 +302,6 @@ async def _sign_request_hook(
 
     # Get AWS credentials from the session
     credentials = session_holder.session.get_credentials()
-    logger.debug(
-        'Signing request with credentials for access key: %s...%s',
-        credentials.access_key[:4],
-        credentials.access_key[-4:],
-    )
 
     # Create SigV4 auth and use its signing logic
     auth = SigV4HTTPXAuth(credentials, service, region)

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -128,6 +128,7 @@ class SessionHolder:
     """
 
     def __init__(self, session: boto3.Session, profile: Optional[str] = None) -> None:
+        """Initialize SessionHolder with the given session and optional profile."""
         self.session = session
         self._profile = profile
         self._needs_refresh = False
@@ -145,7 +146,9 @@ class SessionHolder:
             self.session = create_aws_session(self._profile)
             self._needs_refresh = False
         except ValueError:
-            logger.warning('Failed to create fresh AWS session, keeping current session', exc_info=True)
+            logger.warning(
+                'Failed to create fresh AWS session, keeping current session', exc_info=True
+            )
 
 
 def create_sigv4_client(
@@ -174,7 +177,6 @@ def create_sigv4_client(
     Returns:
         httpx.AsyncClient with SigV4 authentication
     """
-
     # Create a copy of kwargs to avoid modifying the passed dict
     client_kwargs = {
         'follow_redirects': True,

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -120,12 +120,39 @@ def create_aws_session(profile: Optional[str] = None) -> boto3.Session:
     return session
 
 
+class SessionHolder:
+    """Holds a boto3 session that can be refreshed on credential errors.
+
+    Wraps a boto3.Session so the signing hook always uses the current session,
+    and can create a fresh session when the previous request got an auth error.
+    """
+
+    def __init__(self, session: boto3.Session, profile: Optional[str] = None) -> None:
+        self.session = session
+        self._profile = profile
+        self._needs_refresh = False
+
+    def mark_needs_refresh(self) -> None:
+        """Mark that the next request should use a fresh session."""
+        self._needs_refresh = True
+
+    def refresh_if_needed(self) -> None:
+        """Create a fresh session if a previous request got an auth error."""
+        if not self._needs_refresh:
+            return
+        self._needs_refresh = False
+        logger.info('Refreshing AWS session to pick up new credentials')
+        try:
+            self.session = create_aws_session(self._profile)
+        except ValueError:
+            logger.warning('Failed to create fresh AWS session, keeping current session')
+
+
 def create_sigv4_client(
     service: str,
     region: str,
+    session_holder: SessionHolder,
     timeout: Optional[httpx.Timeout] = None,
-    profile: Optional[str] = None,
-    session: Optional[boto3.Session] = None,
     headers: Optional[Dict[str, str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
     disable_telemetry: bool = False,
@@ -135,9 +162,9 @@ def create_sigv4_client(
 
     Args:
         service: AWS service name for SigV4 signing
-        profile: AWS profile to use (optional, only used if session is not provided)
-        session: AWS boto3 session to use (optional, takes precedence over profile)
-        region: AWS region (optional, defaults to AWS_REGION env var or us-east-1)
+        region: AWS region for SigV4 signing
+        session_holder: SessionHolder that provides the current boto3 session
+            and can refresh it on credential errors
         timeout: Timeout configuration for the HTTP client
         headers: Headers to include in requests
         metadata: Metadata to inject into MCP _meta field
@@ -147,9 +174,6 @@ def create_sigv4_client(
     Returns:
         httpx.AsyncClient with SigV4 authentication
     """
-    # Create or use provided AWS session
-    if session is None:
-        session = create_aws_session(profile)
 
     # Create a copy of kwargs to avoid modifying the passed dict
     client_kwargs = {
@@ -184,28 +208,33 @@ def create_sigv4_client(
     return httpx.AsyncClient(
         **client_kwargs,
         event_hooks={
-            'response': [_handle_error_response],
+            'response': [partial(_handle_error_response, session_holder)],
             'request': [
                 partial(_inject_metadata_hook, metadata or {}),
-                partial(_sign_request_hook, region, service, session),
+                partial(_sign_request_hook, region, service, session_holder),
             ],
         },
     )
 
 
-async def _handle_error_response(response: httpx.Response) -> None:
+async def _handle_error_response(session_holder: SessionHolder, response: httpx.Response) -> None:
     """Event hook to handle HTTP error responses and extract details.
 
     This function is called for every HTTP response to check for errors
     and provide more detailed error information when requests fail.
 
     Args:
+        session_holder: SessionHolder to refresh on credential errors
         response: The HTTP response object
 
     Raises:
         No raises. let the mcp http client handle the errors.
     """
     if response.is_error:
+        # Mark session for refresh so the next request picks up new credentials
+        if response.status_code in (401, 403):
+            session_holder.mark_needs_refresh()
+
         # warning only because the SDK logs error
         log_level = logging.WARNING
         if (
@@ -246,7 +275,7 @@ async def _handle_error_response(response: httpx.Response) -> None:
 async def _sign_request_hook(
     region: str,
     service: str,
-    session: boto3.Session,
+    session_holder: SessionHolder,
     request: httpx.Request,
 ) -> None:
     """Request hook to sign HTTP requests with AWS SigV4.
@@ -258,14 +287,19 @@ async def _sign_request_hook(
     Args:
         region: AWS region for SigV4 signing
         service: AWS service name for SigV4 signing
-        session: AWS boto3 session to use for credentials
+        session_holder: Holder providing the current boto3 session (refreshed on auth errors)
         request: The HTTP request object to sign (modified in-place)
     """
     # Set Content-Length for signing
     request.headers['Content-Length'] = str(len(request.content))
 
+    # Refresh session if a previous request got an auth error.
+    # Done here (at signing time) so the new session reads credentials
+    # that the user may have refreshed since the error occurred.
+    session_holder.refresh_if_needed()
+
     # Get AWS credentials from the session
-    credentials = session.get_credentials()
+    credentials = session_holder.session.get_credentials()
     logger.debug(
         'Signing request with credentials for access key: %s...%s',
         credentials.access_key[:4],

--- a/mcp_proxy_for_aws/utils.py
+++ b/mcp_proxy_for_aws/utils.py
@@ -19,7 +19,7 @@ import httpx
 import logging
 import os
 from fastmcp.client.transports import StreamableHttpTransport
-from mcp_proxy_for_aws.sigv4_helper import create_aws_session, create_sigv4_client
+from mcp_proxy_for_aws.sigv4_helper import SessionHolder, create_aws_session, create_sigv4_client
 from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -90,9 +90,10 @@ def create_transport_with_sigv4(
     Returns:
         StreamableHttpTransport instance with SigV4 authentication
     """
-    # Create AWS session once and reuse it for all httpx clients
+    # Create AWS session with a holder that can refresh on credential errors
     logger.debug('Creating AWS session with profile: %s', profile)
     session = create_aws_session(profile)
+    session_holder = SessionHolder(session, profile)
 
     def client_factory(
         headers: Optional[Dict[str, str]] = None,
@@ -102,7 +103,7 @@ def create_transport_with_sigv4(
     ) -> httpx.AsyncClient:
         return create_sigv4_client(
             service=service,
-            session=session,
+            session_holder=session_holder,
             region=region,
             headers=headers,
             timeout=custom_timeout,

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -19,6 +19,7 @@ import json
 import pytest
 from functools import partial
 from mcp_proxy_for_aws.sigv4_helper import (
+    SessionHolder,
     _handle_error_response,
     _inject_metadata_hook,
     _sign_request_hook,
@@ -52,6 +53,13 @@ def create_mock_session():
     return mock_session
 
 
+def create_mock_session_holder():
+    """Helper to create a mocked SessionHolder."""
+    holder = MagicMock(spec=SessionHolder)
+    holder.session = create_mock_session()
+    return holder
+
+
 class TestHandleErrorResponse:
     """Test cases for the _handle_error_response function."""
 
@@ -68,7 +76,7 @@ class TestHandleErrorResponse:
             request=request,
         )
 
-        await _handle_error_response(response)
+        await _handle_error_response(create_mock_session_holder(), response)
 
         # Verify response was read (content should be settled)
         assert response.is_stream_consumed
@@ -85,7 +93,7 @@ class TestHandleErrorResponse:
             request=request,
         )
 
-        await _handle_error_response(response)
+        await _handle_error_response(create_mock_session_holder(), response)
 
         # Verify response was read
         assert response.is_stream_consumed
@@ -102,7 +110,7 @@ class TestHandleErrorResponse:
             request=request,
         )
 
-        await _handle_error_response(response)
+        await _handle_error_response(create_mock_session_holder(), response)
 
         # Verify function completes without error for success responses
         assert response.status_code == 200
@@ -125,7 +133,7 @@ class TestHandleErrorResponse:
             )
         )
 
-        await _handle_error_response(response)
+        await _handle_error_response(create_mock_session_holder(), response)
 
         # Verify it handled the read failure gracefully (no exception raised)
         # The aread() was attempted (would have been called)
@@ -143,7 +151,7 @@ class TestHandleErrorResponse:
             request=request,
         )
 
-        await _handle_error_response(response)
+        await _handle_error_response(create_mock_session_holder(), response)
 
         # Verify response was read despite invalid JSON
         assert response.is_stream_consumed
@@ -346,20 +354,16 @@ class TestSignRequestHook:
     @pytest.mark.asyncio
     async def test_sign_request_hook_signs_request(self):
         """Test that sign_request_hook properly signs requests."""
-        # Setup mocks
-        mock_session = create_mock_session()
+        holder = create_mock_session_holder()
 
         region = 'us-east-1'
         service = 'bedrock-agentcore'
 
-        # Create request without signature headers
         request_body = json.dumps({'test': 'data'}).encode('utf-8')
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
 
-        # Call the hook
-        await _sign_request_hook(region, service, mock_session, request)
+        await _sign_request_hook(region, service, holder, request)
 
-        # Verify signature headers were added
         assert 'authorization' in request.headers
         assert 'x-amz-date' in request.headers
         assert 'x-amz-security-token' in request.headers
@@ -368,8 +372,7 @@ class TestSignRequestHook:
     @pytest.mark.asyncio
     async def test_sign_request_hook_with_profile(self):
         """Test that sign_request_hook uses session when provided."""
-        # Setup mocks
-        mock_session = create_mock_session()
+        holder = create_mock_session_holder()
 
         region = 'us-west-2'
         service = 'execute-api'
@@ -377,49 +380,40 @@ class TestSignRequestHook:
         request_body = b'test content'
         request = httpx.Request('POST', 'https://example.com/api', content=request_body)
 
-        # Call the hook
-        await _sign_request_hook(region, service, mock_session, request)
+        await _sign_request_hook(region, service, holder, request)
 
-        # Verify request was signed
         assert 'authorization' in request.headers
         assert 'x-amz-date' in request.headers
 
     @pytest.mark.asyncio
     async def test_sign_request_hook_sets_content_length(self):
         """Test that sign_request_hook sets Content-Length header."""
-        # Setup mocks
-        mock_session = create_mock_session()
+        holder = create_mock_session_holder()
 
         region = 'eu-west-1'
         service = 'lambda'
 
-        # Create request
         request_body = b'test content with specific length'
         request = httpx.Request('POST', 'https://example.com/api', content=request_body)
 
-        await _sign_request_hook(region, service, mock_session, request)
+        await _sign_request_hook(region, service, holder, request)
 
-        # Verify Content-Length was set correctly
         assert request.headers['content-length'] == str(len(request_body))
 
     @pytest.mark.asyncio
     async def test_sign_request_hook_with_partial_application(self):
         """Test that sign_request_hook works with functools.partial."""
-        # Setup mocks
-        mock_session = create_mock_session()
+        holder = create_mock_session_holder()
 
         region = 'ap-southeast-1'
         service = 'execute-api'
 
-        # Create curried function using partial
-        curried_hook = partial(_sign_request_hook, region, service, mock_session)
+        curried_hook = partial(_sign_request_hook, region, service, holder)
 
         request_body = b'request data'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
 
-        # Call the curried function (only needs request parameter)
         await curried_hook(request)
 
-        # Verify request was signed
         assert 'authorization' in request.headers
         assert 'x-amz-date' in request.headers

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -64,6 +64,55 @@ class TestHandleErrorResponse:
     """Test cases for the _handle_error_response function."""
 
     @pytest.mark.asyncio
+    async def test_handle_error_response_marks_refresh_on_401(self):
+        """401 response marks the session holder for refresh."""
+        request = httpx.Request('POST', 'https://example.com/mcp')
+        response = httpx.Response(
+            status_code=401,
+            headers={'content-type': 'text/plain'},
+            content=b'Unauthorized',
+            request=request,
+        )
+        holder = create_mock_session_holder()
+
+        await _handle_error_response(holder, response)
+
+        holder.mark_needs_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_error_response_marks_refresh_on_403(self):
+        """403 response marks the session holder for refresh."""
+        request = httpx.Request('POST', 'https://example.com/mcp')
+        response = httpx.Response(
+            status_code=403,
+            headers={'content-type': 'text/plain'},
+            content=b'Forbidden',
+            request=request,
+        )
+        holder = create_mock_session_holder()
+
+        await _handle_error_response(holder, response)
+
+        holder.mark_needs_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_error_response_does_not_mark_refresh_on_other_errors(self):
+        """Non-auth error codes (400, 404, 500) do not mark refresh."""
+        for status_code in (400, 404, 500):
+            request = httpx.Request('POST', 'https://example.com/mcp')
+            response = httpx.Response(
+                status_code=status_code,
+                headers={'content-type': 'text/plain'},
+                content=b'Error',
+                request=request,
+            )
+            holder = create_mock_session_holder()
+
+            await _handle_error_response(holder, response)
+
+            holder.mark_needs_refresh.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_handle_error_response_with_json_error(self):
         """Test error handling with JSON error response."""
         # Create a mock error response with JSON content
@@ -350,6 +399,17 @@ class TestMetadataInjectionHook:
 
 class TestSignRequestHook:
     """Test cases for sign_request_hook function."""
+
+    @pytest.mark.asyncio
+    async def test_sign_request_hook_calls_refresh_if_needed(self):
+        """Signing hook calls refresh_if_needed before signing."""
+        holder = create_mock_session_holder()
+        request_body = b'{"test": "data"}'
+        request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
+
+        await _sign_request_hook('us-east-1', 'execute-api', holder, request)
+
+        holder.refresh_if_needed.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_sign_request_hook_signs_request(self):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -22,7 +22,7 @@ from mcp_proxy_for_aws.server import (
     parse_args,
     run_proxy,
 )
-from mcp_proxy_for_aws.sigv4_helper import create_sigv4_client
+from mcp_proxy_for_aws.sigv4_helper import SessionHolder, create_sigv4_client
 from mcp_proxy_for_aws.utils import determine_service_name
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -403,48 +403,28 @@ class TestServer:
             result = determine_service_name(endpoint)
             assert result == expected_service
 
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('mcp_proxy_for_aws.sigv4_helper.httpx.AsyncClient')
-    def test_create_sigv4_client(self, mock_async_client, mock_create_session):
-        """Test creating SigV4 authenticated client with request hooks.
-
-        Note: Session creation and signing now happens in sign_request_hook,
-        not during client creation.
-        """
-        # Mock session creation
+    def test_create_sigv4_client(self, mock_async_client):
+        """Test creating SigV4 authenticated client with request hooks."""
         mock_session = Mock()
         mock_session.get_credentials.return_value = Mock(access_key='test-key')
-        mock_create_session.return_value = mock_session
+        session_holder = SessionHolder(mock_session, profile='test-profile')
 
-        # Act
-        create_sigv4_client(service='test-service', region='us-west-2', profile='test-profile')
+        create_sigv4_client(service='test-service', region='us-west-2', session_holder=session_holder)
 
-        # Assert
-        # Verify session was created with profile
-        mock_create_session.assert_called_once_with('test-profile')
-        # Verify AsyncClient was called (signing happens via hooks)
         assert mock_async_client.call_count == 1
         call_args = mock_async_client.call_args
-        # Verify hooks are registered
         assert 'event_hooks' in call_args[1]
         assert 'request' in call_args[1]['event_hooks']
         assert 'response' in call_args[1]['event_hooks']
-        # Should have metadata injection + sign hooks
         assert len(call_args[1]['event_hooks']['request']) == 2
 
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
-    def test_create_sigv4_client_no_credentials(self, mock_create_session):
-        """Test that credential check happens in sign_request_hook, not during client creation.
-
-        Note: With the refactoring, client creation no longer validates credentials.
-        Credential validation now happens in sign_request_hook when the request is signed.
-        """
+    def test_create_sigv4_client_no_credentials(self):
+        """Test that credential check happens in sign_request_hook, not during client creation."""
         mock_session = Mock()
-        mock_create_session.return_value = mock_session
+        session_holder = SessionHolder(mock_session)
 
-        # Client creation should succeed even without credentials
-        # (credentials are checked when signing happens)
-        client = create_sigv4_client(service='test-service', region='test-region')
+        client = create_sigv4_client(service='test-service', region='test-region', session_holder=session_holder)
         assert client is not None
 
     def test_main_module_execution(self):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -410,7 +410,9 @@ class TestServer:
         mock_session.get_credentials.return_value = Mock(access_key='test-key')
         session_holder = SessionHolder(mock_session, profile='test-profile')
 
-        create_sigv4_client(service='test-service', region='us-west-2', session_holder=session_holder)
+        create_sigv4_client(
+            service='test-service', region='us-west-2', session_holder=session_holder
+        )
 
         assert mock_async_client.call_count == 1
         call_args = mock_async_client.call_args
@@ -424,7 +426,9 @@ class TestServer:
         mock_session = Mock()
         session_holder = SessionHolder(mock_session)
 
-        client = create_sigv4_client(service='test-service', region='test-region', session_holder=session_holder)
+        client = create_sigv4_client(
+            service='test-service', region='test-region', session_holder=session_holder
+        )
         assert client is not None
 
     def test_main_module_execution(self):

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -127,9 +127,7 @@ class TestCreateSigv4Client:
 
     @patch('mcp_proxy_for_aws.sigv4_helper.get_client_info', return_value=None)
     @patch('httpx.AsyncClient')
-    def test_create_sigv4_client_default(
-        self, mock_client_class, mock_get_client_info
-    ):
+    def test_create_sigv4_client_default(self, mock_client_class, mock_get_client_info):
         """Test creating SigV4 client with default parameters."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
@@ -137,7 +135,9 @@ class TestCreateSigv4Client:
         session_holder = SessionHolder(mock_session)
 
         # Test client creation
-        result = create_sigv4_client(service='test-service', region='test-region', session_holder=session_holder)
+        result = create_sigv4_client(
+            service='test-service', region='test-region', session_holder=session_holder
+        )
 
         # Check that AsyncClient was called with correct parameters
         call_args = mock_client_class.call_args
@@ -165,7 +165,10 @@ class TestCreateSigv4Client:
         # Test client creation with custom headers
         custom_headers = {'Custom-Header': 'custom-value'}
         result = create_sigv4_client(
-            service='test-service', region='test-region', session_holder=session_holder, headers=custom_headers
+            service='test-service',
+            region='test-region',
+            session_holder=session_holder,
+            headers=custom_headers,
         )
 
         # Verify client was created with merged headers
@@ -179,9 +182,7 @@ class TestCreateSigv4Client:
         assert result == mock_client
 
     @patch('httpx.AsyncClient')
-    def test_create_sigv4_client_with_custom_service_and_region(
-        self, mock_client_class
-    ):
+    def test_create_sigv4_client_with_custom_service_and_region(self, mock_client_class):
         """Test creating SigV4 client with custom service and region."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
@@ -236,7 +237,10 @@ class TestCreateSigv4Client:
         }
 
         result = create_sigv4_client(
-            service='test-service', session_holder=session_holder, headers=prompt_context_headers, region='us-west-2'
+            service='test-service',
+            session_holder=session_holder,
+            headers=prompt_context_headers,
+            region='us-west-2',
         )
 
         # Check that AsyncClient was called with correct parameters including prompt headers
@@ -270,7 +274,10 @@ class TestCreateSigv4Client:
         mock_get_client_info.return_value = Implementation(name='My Client', version='2.0')
 
         result = create_sigv4_client(
-            service='test-service', region='test-region', session_holder=session_holder, disable_telemetry=True
+            service='test-service',
+            region='test-region',
+            session_holder=session_holder,
+            disable_telemetry=True,
         )
 
         call_args = mock_client_class.call_args
@@ -292,7 +299,10 @@ class TestCreateSigv4Client:
         mock_get_client_info.return_value = Implementation(name='My Client', version='2.0')
 
         result = create_sigv4_client(
-            service='test-service', region='test-region', session_holder=session_holder, disable_telemetry=False
+            service='test-service',
+            region='test-region',
+            session_holder=session_holder,
+            disable_telemetry=False,
         )
 
         call_args = mock_client_class.call_args

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -15,6 +15,7 @@
 """Unit tests for sigv4_helper module."""
 
 import httpx
+import logging
 import pytest
 from httpx import __version__ as httpx_version
 from mcp.types import Implementation
@@ -311,6 +312,77 @@ class TestCreateSigv4Client:
         assert 'mcp-proxy-for-aws' in user_agent
         assert 'my-client/2.0' in user_agent
         assert result == mock_client
+
+
+class TestSessionHolder:
+    """Test cases for the SessionHolder class."""
+
+    def test_refresh_if_needed_noop_when_not_marked(self):
+        """refresh_if_needed does nothing when not marked."""
+        mock_session = Mock()
+        holder = SessionHolder(mock_session)
+
+        holder.refresh_if_needed()
+
+        assert holder.session is mock_session
+
+    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
+    def test_refresh_if_needed_creates_new_session_when_marked(self, mock_create):
+        """refresh_if_needed replaces the session after mark_needs_refresh."""
+        old_session = Mock()
+        new_session = Mock()
+        mock_create.return_value = new_session
+        holder = SessionHolder(old_session, profile='my-profile')
+
+        holder.mark_needs_refresh()
+        holder.refresh_if_needed()
+
+        mock_create.assert_called_once_with('my-profile')
+        assert holder.session is new_session
+
+    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
+    def test_refresh_clears_flag_on_success(self, mock_create):
+        """After a successful refresh the flag is cleared — second call is a no-op."""
+        mock_create.return_value = Mock()
+        holder = SessionHolder(Mock())
+
+        holder.mark_needs_refresh()
+        holder.refresh_if_needed()
+        mock_create.reset_mock()
+
+        holder.refresh_if_needed()
+        mock_create.assert_not_called()
+
+    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
+    def test_refresh_keeps_flag_on_failure(self, mock_create):
+        """If refresh fails the flag stays set so the next call retries."""
+        old_session = Mock()
+        mock_create.side_effect = ValueError('no creds')
+        holder = SessionHolder(old_session)
+
+        holder.mark_needs_refresh()
+        holder.refresh_if_needed()
+
+        # Session unchanged
+        assert holder.session is old_session
+        # Flag still set — next call retries
+        mock_create.side_effect = None
+        mock_create.return_value = Mock()
+        holder.refresh_if_needed()
+        assert mock_create.call_count == 2
+
+    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
+    def test_refresh_logs_original_error_on_failure(self, mock_create, caplog):
+        """Failed refresh logs the original ValueError."""
+        mock_create.side_effect = ValueError('session creation boom')
+        holder = SessionHolder(Mock())
+
+        holder.mark_needs_refresh()
+        with caplog.at_level(logging.WARNING):
+            holder.refresh_if_needed()
+
+        assert 'Failed to create fresh AWS session' in caplog.text
+        assert 'session creation boom' in caplog.text
 
 
 class TestSanitizeHeaders:

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -21,6 +21,7 @@ from mcp.types import Implementation
 from mcp_proxy_for_aws import __version__
 from mcp_proxy_for_aws.sigv4_helper import (
     SENSITIVE_HEADERS,
+    SessionHolder,
     SigV4HTTPXAuth,
     _sanitize_headers,
     create_aws_session,
@@ -125,19 +126,18 @@ class TestCreateSigv4Client:
     """Test cases for the create_sigv4_client function."""
 
     @patch('mcp_proxy_for_aws.sigv4_helper.get_client_info', return_value=None)
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('httpx.AsyncClient')
     def test_create_sigv4_client_default(
-        self, mock_client_class, mock_create_session, mock_get_client_info
+        self, mock_client_class, mock_get_client_info
     ):
         """Test creating SigV4 client with default parameters."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
         mock_session = Mock()
-        mock_create_session.return_value = mock_session
+        session_holder = SessionHolder(mock_session)
 
         # Test client creation
-        result = create_sigv4_client(service='test-service', region='test-region')
+        result = create_sigv4_client(service='test-service', region='test-region', session_holder=session_holder)
 
         # Check that AsyncClient was called with correct parameters
         call_args = mock_client_class.call_args
@@ -153,21 +153,19 @@ class TestCreateSigv4Client:
         assert result == mock_client
 
     @patch('mcp_proxy_for_aws.sigv4_helper.get_client_info', return_value=None)
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('httpx.AsyncClient')
     def test_create_sigv4_client_with_custom_headers(
-        self, mock_client_class, mock_create_session, mock_get_client_info
+        self, mock_client_class, mock_get_client_info
     ):
         """Test creating SigV4 client with custom headers."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        mock_session = Mock()
-        mock_create_session.return_value = mock_session
+        session_holder = SessionHolder(Mock())
 
         # Test client creation with custom headers
         custom_headers = {'Custom-Header': 'custom-value'}
         result = create_sigv4_client(
-            service='test-service', region='test-region', headers=custom_headers
+            service='test-service', region='test-region', session_holder=session_holder, headers=custom_headers
         )
 
         # Verify client was created with merged headers
@@ -180,43 +178,38 @@ class TestCreateSigv4Client:
         assert call_args[1]['headers'] == expected_headers
         assert result == mock_client
 
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('httpx.AsyncClient')
     def test_create_sigv4_client_with_custom_service_and_region(
-        self, mock_client_class, mock_create_session
+        self, mock_client_class
     ):
         """Test creating SigV4 client with custom service and region."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
 
-        # Mock session creation
         mock_session = Mock()
         mock_session.get_credentials.return_value = Mock(access_key='test-key')
-        mock_create_session.return_value = mock_session
+        session_holder = SessionHolder(mock_session, profile='test-profile')
 
         # Test client creation with custom parameters
         result = create_sigv4_client(
-            service='custom-service', profile='test-profile', region='us-east-1'
+            service='custom-service', session_holder=session_holder, region='us-east-1'
         )
 
-        # Verify session was created with profile
-        mock_create_session.assert_called_once_with('test-profile')
         # Verify client was created
         assert result == mock_client
 
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('httpx.AsyncClient')
-    def test_create_sigv4_client_with_kwargs(self, mock_client_class, mock_create_session):
+    def test_create_sigv4_client_with_kwargs(self, mock_client_class):
         """Test creating SigV4 client with additional kwargs."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        mock_session = Mock()
-        mock_create_session.return_value = mock_session
+        session_holder = SessionHolder(Mock())
 
         # Test client creation with additional kwargs
         result = create_sigv4_client(
             service='test-service',
             region='test-region',
+            session_holder=session_holder,
             verify=False,
             proxies={'http': 'http://proxy:8080'},
         )
@@ -228,30 +221,22 @@ class TestCreateSigv4Client:
         assert result == mock_client
 
     @patch('mcp_proxy_for_aws.sigv4_helper.get_client_info', return_value=None)
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('httpx.AsyncClient')
     def test_create_sigv4_client_with_prompt_context(
-        self, mock_client_class, mock_create_session, mock_get_client_info
+        self, mock_client_class, mock_get_client_info
     ):
-        """Test creating SigV4 client when prompts exist in the system context.
-
-        This test simulates the scenario where the sigv4_helper is used in a context
-        where MCP prompts are present, ensuring the client is properly configured
-        to handle requests that might include prompt-related content or headers.
-        """
+        """Test creating SigV4 client when prompts exist in the system context."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        mock_session = Mock()
-        mock_create_session.return_value = mock_session
+        session_holder = SessionHolder(Mock())
 
-        # Test client creation with headers that might be used when prompts exist
         prompt_context_headers = {
             'X-MCP-Prompt-Context': 'enabled',
             'Content-Type': 'application/json',
         }
 
         result = create_sigv4_client(
-            service='test-service', headers=prompt_context_headers, region='us-west-2'
+            service='test-service', session_holder=session_holder, headers=prompt_context_headers, region='us-west-2'
         )
 
         # Check that AsyncClient was called with correct parameters including prompt headers
@@ -274,20 +259,18 @@ class TestCreateSigv4Client:
         assert result == mock_client
 
     @patch('mcp_proxy_for_aws.sigv4_helper.get_client_info')
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('httpx.AsyncClient')
     def test_create_sigv4_client_user_agent_excludes_client_info_when_telemetry_disabled(
-        self, mock_client_class, mock_create_session, mock_get_client_info
+        self, mock_client_class, mock_get_client_info
     ):
         """Test that User-Agent omits client info when disable_telemetry is True."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        mock_session = Mock()
-        mock_create_session.return_value = mock_session
+        session_holder = SessionHolder(Mock())
         mock_get_client_info.return_value = Implementation(name='My Client', version='2.0')
 
         result = create_sigv4_client(
-            service='test-service', region='test-region', disable_telemetry=True
+            service='test-service', region='test-region', session_holder=session_holder, disable_telemetry=True
         )
 
         call_args = mock_client_class.call_args
@@ -298,20 +281,18 @@ class TestCreateSigv4Client:
         assert result == mock_client
 
     @patch('mcp_proxy_for_aws.sigv4_helper.get_client_info')
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
     @patch('httpx.AsyncClient')
     def test_create_sigv4_client_user_agent_includes_client_info_when_telemetry_enabled(
-        self, mock_client_class, mock_create_session, mock_get_client_info
+        self, mock_client_class, mock_get_client_info
     ):
         """Test that User-Agent includes client info when disable_telemetry is False."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        mock_session = Mock()
-        mock_create_session.return_value = mock_session
+        session_holder = SessionHolder(Mock())
         mock_get_client_info.return_value = Implementation(name='My Client', version='2.0')
 
         result = create_sigv4_client(
-            service='test-service', region='test-region', disable_telemetry=False
+            service='test-service', region='test-region', session_holder=session_holder, disable_telemetry=False
         )
 
         call_args = mock_client_class.call_args

--- a/tests/unit/test_tool_error_middleware.py
+++ b/tests/unit/test_tool_error_middleware.py
@@ -98,7 +98,7 @@ class TestToolErrorMiddleware:
 
         with pytest.raises(ToolError, match='expired or invalid AWS credentials') as exc_info:
             await middleware.on_call_tool(context, call_next)
-        assert '--profile' in str(exc_info.value)
+        assert 'refresh your credentials' in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_non_credential_error_no_suggestion(self):

--- a/tests/unit/test_tool_error_middleware.py
+++ b/tests/unit/test_tool_error_middleware.py
@@ -101,6 +101,52 @@ class TestToolErrorMiddleware:
         assert 'refresh your credentials' in str(exc_info.value)
 
     @pytest.mark.asyncio
+    async def test_credential_error_on_403(self):
+        """403 Forbidden is recognised as a credential error."""
+        middleware = _make_middleware()
+        response = Mock(spec=httpx.Response)
+        response.status_code = 403
+        call_next = AsyncMock(
+            side_effect=httpx.HTTPStatusError('Forbidden', request=Mock(), response=response)
+        )
+        context = _make_context()
+
+        with pytest.raises(ToolError, match='expired or invalid AWS credentials'):
+            await middleware.on_call_tool(context, call_next)
+
+    @pytest.mark.asyncio
+    async def test_credential_error_wrapped_in_cause(self):
+        """401 wrapped via __cause__ is still detected."""
+        middleware = _make_middleware()
+        response = Mock(spec=httpx.Response)
+        response.status_code = 401
+        inner = httpx.HTTPStatusError('Unauthorized', request=Mock(), response=response)
+        outer = RuntimeError('request failed')
+        outer.__cause__ = inner
+
+        call_next = AsyncMock(side_effect=outer)
+        context = _make_context()
+
+        with pytest.raises(ToolError, match='expired or invalid AWS credentials'):
+            await middleware.on_call_tool(context, call_next)
+
+    @pytest.mark.asyncio
+    async def test_credential_error_wrapped_in_context(self):
+        """401 wrapped via __context__ (implicit chaining) is still detected."""
+        middleware = _make_middleware()
+        response = Mock(spec=httpx.Response)
+        response.status_code = 401
+        inner = httpx.HTTPStatusError('Unauthorized', request=Mock(), response=response)
+        outer = RuntimeError('wrapped')
+        outer.__context__ = inner
+
+        call_next = AsyncMock(side_effect=outer)
+        context = _make_context()
+
+        with pytest.raises(ToolError, match='expired or invalid AWS credentials'):
+            await middleware.on_call_tool(context, call_next)
+
+    @pytest.mark.asyncio
     async def test_non_credential_error_no_suggestion(self):
         """Non-credential errors do not suggest credential remediation."""
         middleware = _make_middleware()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -22,7 +22,7 @@ from mcp_proxy_for_aws.utils import (
     determine_service_name,
     validate_endpoint_url,
 )
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 
 class TestValidateEndpointUrl:
@@ -153,7 +153,7 @@ class TestCreateTransportWithSigv4:
 
             mock_create_sigv4_client.assert_called_once_with(
                 service=service,
-                session=mock_session,
+                session_holder=ANY,
                 region=region,
                 headers={'test': 'header'},
                 timeout=custom_timeout,
@@ -195,7 +195,7 @@ class TestCreateTransportWithSigv4:
 
             mock_create_sigv4_client.assert_called_once_with(
                 service=service,
-                session=mock_session,
+                session_holder=ANY,
                 region=region,
                 headers=None,
                 timeout=custom_timeout,
@@ -233,7 +233,7 @@ class TestCreateTransportWithSigv4:
 
         mock_create_sigv4_client.assert_called_once_with(
             service=service,
-            session=mock_session,
+            session_holder=ANY,
             region=region,
             headers=None,
             timeout=custom_timeout,


### PR DESCRIPTION
When AWS credentials expire, the proxy now automatically picks up refreshed credentials on the next request without requiring a restart.

Problem:
- boto3.Session was created once at startup and cached forever
- session.get_credentials() returned the same stale Credentials object
- Even after refreshing creds on disk (e.g. aws sso login), the proxy kept using the old frozen session until restarted

Fix:
- Add SessionHolder that wraps the boto3 session with lazy refresh
- On 401/403, mark the session for refresh (don't refresh immediately, since creds on disk may not be updated yet)
- On the next request's signing, create a fresh boto3.Session that reads the current credentials from disk
- Improve error messages: credential errors now clearly say 'expired or invalid AWS credentials' instead of 'Unknown tool'

The lazy refresh pattern ensures the new session is created at signing time (after the user has refreshed creds), not at error time (when creds may still be stale).

## Testing

### Manual credential expiry test

Used the following script to verify end-to-end: get credentials, connect to the AWS MCP server, wait 20 minutes for expiry, refresh credentials, and make another request.

```python
"""Manual test for credential refresh across session expiry."""

import asyncio
import fastmcp
import logging
import subprocess
import sys
from fastmcp.client import StdioTransport

logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
logger = logging.getLogger(__name__)

for _name in ('fastmcp', 'mcp', 'httpx', 'httpcore', 'botocore', 'urllib3'):
    logging.getLogger(_name).setLevel(logging.CRITICAL)

REFRESH_COMMAND = ['your-credential-refresh-command', '--once']
ENDPOINT = 'https://aws-mcp.us-east-1.api.aws/mcp'
REGION = 'us-east-1'
WAIT_MINUTES = 20


def refresh_credentials():
    logger.info('Running: %s', ' '.join(REFRESH_COMMAND))
    result = subprocess.run(REFRESH_COMMAND, capture_output=True, text=True)
    if result.returncode != 0:
        logger.error('Credential refresh failed (exit %d):\n%s', result.returncode, result.stderr)
        sys.exit(1)
    logger.info('Credentials refreshed')


async def make_request(client: fastmcp.Client):
    await client.ping()
    logger.info('Ping OK')
    tools = await client.list_tools()
    logger.info('Listed %d tools', len(tools))
    response = await client.call_tool('aws___list_regions', {})
    assert response.is_error is False, f'Tool call failed: {response}'
    logger.info('list_regions call succeeded')


async def main():
    refresh_credentials()
    client = fastmcp.Client(
        StdioTransport(
            command='mcp-proxy-for-aws',
            args=[ENDPOINT, '--region', REGION, '--log-level', 'CRITICAL'],
        ),
        timeout=30.0,
    )
    async with client:
        logger.info('--- First request (fresh credentials) ---')
        await make_request(client)
        logger.info('Waiting %d minutes for credentials to expire...', WAIT_MINUTES)
        await asyncio.sleep(WAIT_MINUTES * 60)
        refresh_credentials()
        logger.info('--- Second request (after credential refresh) ---')
        await make_request(client)
    logger.info('Test passed: both requests succeeded')


if __name__ == '__main__':
    asyncio.run(main())
```

Result:

```
2026-04-14 14:16:44,956 INFO list_regions call succeeded
2026-04-14 14:16:44,957 INFO Test passed: both requests succeeded
```

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.