### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ members = [
 name = "mcp-proxy-for-aws"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "1.3.0"
+version = "1.4.0"
 
 description = "MCP Proxy for AWS"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2932,7 +2932,7 @@ requires-dist = [
 
 [[package]]
 name = "mcp-proxy-for-aws"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

### Changes

- Bump version from `1.3.0` to `1.4.0` in `pyproject.toml` and `uv.lock`

### User experience

Prepares the next release which includes the following changes since v1.3.0:

**Fixes**
- fix: refresh stale credentials on auth failure without restart (#245)
- fix(auth): remove sensitive credential logging (#242)
- fix: remove fast fail credential check from create_aws_session (#233)
- fix: disable SBOM upload to immutable GitHub release (#247)
- fix: increase test timeout for integration tests (#165)

**Chores**
- chore: schedule dependabot PRs at 7 AM monday (#246)
- chore(deps): update uv dependencies (#243, #240, #244)

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

N/A — version bump only.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.