### PR TITLE
fix: catch HTTPStatusError during force disconnect retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Handle `HTTPStatusError` during force disconnect to allow connection retry with refreshed credentials (#262)
+
 ## v1.3.0 (2026-04-10)
 
 ### Added

--- a/mcp_proxy_for_aws/proxy.py
+++ b/mcp_proxy_for_aws/proxy.py
@@ -67,13 +67,14 @@ class AWSMCPProxyClient(StatefulProxyClient):
             try:
                 logger.warning('encountered runtime error, try force disconnect.', exc_info=e)
                 await self._disconnect(force=True)
-            except httpx.TimeoutException:
-                # _disconnect awaits on the session_task,
-                # which raises the timeout error that caused the client session to be terminated.
-                # the error is ignored as long as the counter is force set to 0.
-                # TODO: investigate how timeout error is handled by fastmcp and httpx
-                logger.exception(
-                    'Session was terminated due to timeout error, ignore and reconnect'
+            except (httpx.TimeoutException, httpx.HTTPStatusError):
+                # _disconnect(force=True) resets the nesting counter then awaits the
+                # session_task. That task may re-raise the exception that killed the
+                # session (e.g. HTTPStatusError from a prior 401) or a TimeoutException.
+                # Either way the error is safe to ignore: the counter is already 0 and
+                # the retry below will establish a fresh session with refreshed credentials.
+                logger.warning(
+                    'Session cleanup failed during force disconnect, ignore and reconnect'
                 )
 
             return await self._connect(retry + 1)


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

When a request (e.g. `resources/list`) fails with a 401 due to expired credentials, the session enters a broken state. Subsequent requests (e.g. `tools/list`) attempt to reconnect, hit a `RuntimeError` (nesting counter ≠ 0), and try a force disconnect before retrying. However, `_disconnect(force=True)` awaits the failed session task, which re-raises the original `HTTPStatusError`.
### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
