### PR TITLE
fix: pass-through server capabilities

### DIFF
--- a/mcp_proxy_for_aws/middleware/initialize_middleware.py
+++ b/mcp_proxy_for_aws/middleware/initialize_middleware.py
@@ -31,6 +31,23 @@ class InitializeMiddleware(Middleware):
         super().__init__()
         self._client_factory = client_factory
 
+    def _overwrite_init_options(
+        self, context: MiddlewareContext, init_result: mt.InitializeResult
+    ):
+        """Overwrite the session's _init_options with the backend server's info.
+
+        The MCP SDK builds the InitializeResult from session._init_options
+        inside call_next. By modifying _init_options before call_next runs,
+        the response sent to the client will contain the backend server's
+        info instead of the proxy's defaults.
+        """
+        fastmcp_ctx = context.fastmcp_context
+        if fastmcp_ctx is None or fastmcp_ctx._session is None:
+            logger.debug('No session available, skipping init_options overwrite.')
+            return
+
+        fastmcp_ctx._session._init_options.capabilities = init_result.capabilities
+
     @override
     async def on_initialize(
         self,
@@ -59,6 +76,12 @@ class InitializeMiddleware(Middleware):
                 # the list_tool call will require the client to be connected again, so the mcp error
                 # will be displayed in the q cli logs.
                 await client._connect()
+
+            # Overwrite the proxy's init_options with the backend server's info
+            # so the InitializeResult sent to the client reflects the backend.
+            if client.initialize_result is not None:
+                self._overwrite_init_options(context, client.initialize_result)
+
             return await call_next(context)
         except Exception:
             logger.exception('Initialize failed in middleware.')

--- a/tests/unit/test_initialize_middleware.py
+++ b/tests/unit/test_initialize_middleware.py
@@ -35,6 +35,11 @@ async def test_on_initialize_connects_client():
     """Test that on_initialize calls client._connect()."""
     mock_client = Mock()
     mock_client._connect = AsyncMock()
+    mock_client.initialize_result = mt.InitializeResult(
+        protocolVersion='2024-11-05',
+        capabilities=mt.ServerCapabilities(),
+        serverInfo=mt.Implementation(name='backend-server', version='2.0'),
+    )
 
     mock_factory = Mock()
     mock_factory.set_init_params = Mock()
@@ -42,8 +47,15 @@ async def test_on_initialize_connects_client():
 
     middleware = InitializeMiddleware(mock_factory)
 
+    mock_init_options = Mock()
+    mock_session = Mock()
+    mock_session._init_options = mock_init_options
+    mock_fastmcp_ctx = Mock()
+    mock_fastmcp_ctx._session = mock_session
+
     mock_context = Mock()
     mock_context.message = create_initialize_request('test-client')
+    mock_context.fastmcp_context = mock_fastmcp_ctx
 
     mock_call_next = AsyncMock()
 
@@ -53,6 +65,9 @@ async def test_on_initialize_connects_client():
     mock_factory.get_client.assert_called_once()
     mock_client._connect.assert_called_once()
     mock_call_next.assert_called_once_with(mock_context)
+
+    # Verify init_options capabilities were overwritten with backend server info
+    assert mock_init_options.capabilities == mt.ServerCapabilities()
 
 
 @pytest.mark.asyncio
@@ -94,6 +109,7 @@ async def test_on_initialize_skips_connect_for_special_clients(client_name):
     """Test that on_initialize skips _connect() for Kiro CLI and Q Dev CLI."""
     mock_client = Mock()
     mock_client._connect = AsyncMock()
+    mock_client.initialize_result = None
 
     mock_factory = Mock()
     mock_factory.set_init_params = Mock()
@@ -109,4 +125,117 @@ async def test_on_initialize_skips_connect_for_special_clients(client_name):
     await middleware.on_initialize(mock_context, mock_call_next)
 
     mock_client._connect.assert_not_called()
+    mock_call_next.assert_called_once_with(mock_context)
+
+
+@pytest.mark.asyncio
+async def test_on_initialize_overwrites_init_options_with_backend_info():
+    """Test that on_initialize overwrites session init_options with backend server info."""
+    backend_capabilities = mt.ServerCapabilities(
+        logging=mt.LoggingCapability(),
+    )
+    backend_result = mt.InitializeResult(
+        protocolVersion='2024-11-05',
+        capabilities=backend_capabilities,
+        serverInfo=mt.Implementation(name='backend-mcp', version='3.1'),
+    )
+
+    mock_client = Mock()
+    mock_client._connect = AsyncMock()
+    mock_client.initialize_result = backend_result
+
+    mock_factory = Mock()
+    mock_factory.set_init_params = Mock()
+    mock_factory.get_client = AsyncMock(return_value=mock_client)
+
+    middleware = InitializeMiddleware(mock_factory)
+
+    mock_init_options = Mock()
+    mock_init_options.server_name = 'proxy-name'
+    mock_init_options.server_version = '1.0'
+    mock_init_options.capabilities = mt.ServerCapabilities()
+    mock_session = Mock()
+    mock_session._init_options = mock_init_options
+    mock_fastmcp_ctx = Mock()
+    mock_fastmcp_ctx._session = mock_session
+
+    mock_context = Mock()
+    mock_context.message = create_initialize_request('test-client')
+    mock_context.fastmcp_context = mock_fastmcp_ctx
+
+    mock_call_next = AsyncMock()
+
+    await middleware.on_initialize(mock_context, mock_call_next)
+
+    assert mock_init_options.capabilities == backend_capabilities
+
+
+@pytest.mark.asyncio
+async def test_on_initialize_disables_prompts_and_resources():
+    """Test that prompts and resources capabilities are disabled even if backend supports them."""
+    backend_capabilities = mt.ServerCapabilities(
+        tools=mt.ToolsCapability(),
+        prompts=mt.PromptsCapability(),
+        resources=mt.ResourcesCapability(),
+    )
+    backend_result = mt.InitializeResult(
+        protocolVersion='2024-11-05',
+        capabilities=backend_capabilities,
+        serverInfo=mt.Implementation(name='backend', version='1.0'),
+    )
+
+    mock_client = Mock()
+    mock_client._connect = AsyncMock()
+    mock_client.initialize_result = backend_result
+
+    mock_factory = Mock()
+    mock_factory.set_init_params = Mock()
+    mock_factory.get_client = AsyncMock(return_value=mock_client)
+
+    middleware = InitializeMiddleware(mock_factory)
+
+    mock_init_options = Mock()
+    mock_session = Mock()
+    mock_session._init_options = mock_init_options
+    mock_fastmcp_ctx = Mock()
+    mock_fastmcp_ctx._session = mock_session
+
+    mock_context = Mock()
+    mock_context.message = create_initialize_request('test-client')
+    mock_context.fastmcp_context = mock_fastmcp_ctx
+
+    mock_call_next = AsyncMock()
+
+    await middleware.on_initialize(mock_context, mock_call_next)
+
+    assert mock_init_options.capabilities.prompts is not None
+    assert mock_init_options.capabilities.resources is not None
+    assert mock_init_options.capabilities.tools is not None
+
+
+@pytest.mark.asyncio
+async def test_on_initialize_skips_overwrite_when_no_session():
+    """Test that overwrite is skipped when no session is available."""
+    mock_client = Mock()
+    mock_client._connect = AsyncMock()
+    mock_client.initialize_result = mt.InitializeResult(
+        protocolVersion='2024-11-05',
+        capabilities=mt.ServerCapabilities(),
+        serverInfo=mt.Implementation(name='backend', version='1.0'),
+    )
+
+    mock_factory = Mock()
+    mock_factory.set_init_params = Mock()
+    mock_factory.get_client = AsyncMock(return_value=mock_client)
+
+    middleware = InitializeMiddleware(mock_factory)
+
+    mock_context = Mock()
+    mock_context.message = create_initialize_request('test-client')
+    mock_context.fastmcp_context = None
+
+    mock_call_next = AsyncMock()
+
+    # Should not raise, just skip overwrite
+    await middleware.on_initialize(mock_context, mock_call_next)
     mock_call_next.assert_called_once_with(mock_context)


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

The proxy was returning its own default `ServerCapabilities` to clients during the MCP `initialize` handshake, instead of forwarding the capabilities reported by the backend server. This meant clients had no visibility into what the backend actually supports.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
