### PR TITLE
feat(auth): add per-call AWS profile override middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ docker build -t mcp-proxy-for-aws .
 | `--write-timeout`	   | Set desired write timeout in seconds	                                                                                                                                                                                                   | 180	                                                                        |No	|
 | `--tool-timeout`	   | Maximum seconds a tool call may take before being cancelled. When set, returns a graceful error to the agent instead of hanging indefinitely	                                                                                             | 300	                                                                    |No	|
 | `--disable-telemetry` | Disables telemetry data collection                                                                                                                                                                                                      | `False`                                                                     |No	|
+| `--allow-switch-profile` | Enable per-call AWS profile switching by providing an allowlist of profile names. Each tool call can include a `profile` argument to route through a dedicated connection signed with that profile's credentials. | None (disabled) | No |
 
 ### Optional Environment Variables
 
@@ -164,6 +165,38 @@ Add the following configuration to your MCP client config file (e.g., for Kiro C
 
 > [!NOTE]
 > Cline users should not use `--log-level` argument because Cline checks the log messages in stderr for text "error" (case insensitive).
+
+#### Multi-account access with `--allow-switch-profile`
+
+The `--allow-switch-profile` flag lets individual tool calls route through different AWS profiles without restarting the proxy. This is useful when an AI agent needs to query resources across multiple AWS accounts in a single session.
+
+**How it interacts with `--profile`:**
+- `--profile` sets the **default** identity used when a tool call does not specify a profile.
+- `--allow-switch-profile` defines which additional profiles a tool call may request via a `profile` argument. Each profile gets its own dedicated connection to the backend.
+- If a tool call omits `profile`, the default `--profile` connection is used. If it includes `profile`, the request is routed through the matching per-profile connection instead.
+
+```json
+{
+  "mcpServers": {
+    "<mcp server name>": {
+      "disabled": false,
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "mcp-proxy-for-aws@latest",
+        "<SigV4 MCP endpoint URL>",
+        "--profile",
+        "default",
+        "--allow-switch-profile",
+        "dev-profile",
+        "staging-profile"
+      ]
+    }
+  }
+}
+```
+
+In the example above, tool calls without a `profile` argument use the `default` profile. A tool call that includes `"profile": "dev-profile"` is routed through a dedicated connection signed with `dev-profile` credentials.
 
 #### Using Docker
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docker build -t mcp-proxy-for-aws .
 | `endpoint`	          | MCP endpoint URL (e.g., `https://your-service.us-east-1.amazonaws.com/mcp`)	                                                                                                                                                            | N/A	                                                                        |Yes	|
 | ---	                 | ---	                                                                                                                                                                                                                                    | ---	                                                                        |---	|
 | `--service`	         | AWS service name for SigV4 signing, if omitted we try to infer this from the url	                                                                                                                                                       | Inferred from endpoint if not provided	                                     |No	|
-| `--profile`	         | AWS profile for AWS credentials to use	                                                                                                                                                                                                 | Uses `AWS_PROFILE` environment variable if not set                          |No	|
+| `--profile`	         | AWS profile(s) to use. First profile is the default. Additional profiles enable per-call switching via `aws_profile` tool parameter (e.g., `--profile default dev staging`)	| Uses `AWS_PROFILE` environment variable if not set                          |No	|
 | `--region`	          | AWS region to use	                                                                                                                                                                                                                      | Uses `AWS_REGION` environment variable if not set	                           |No	|
 | `--metadata`	        | Metadata to inject into MCP requests as key=value pairs (e.g., `--metadata KEY1=value1 KEY2=value2`)                                                                                                                                    | `AWS_REGION` is automatically injected based on `--region` if not provided    |No	|
 | `--read-only`	       | Disable tools which may require write permissions (tools which DO NOT require write permissions are annotated with [`readOnlyHint=true`](https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations-readonlyhint)) | `False`	                                                                    |No	|
@@ -126,6 +126,49 @@ export AWS_SESSION_TOKEN=<session_token>
 
 # AWS Region
 export AWS_REGION=<aws_region>
+
+# Multi-profile switching (alternative to --profile flag, useful for plugin integration)
+export AWS_MCP_PROXY_PROFILES="default dev staging"
+```
+
+> **Note:** `AWS_MCP_PROXY_PROFILES` takes precedence over `--profile` / `AWS_PROFILE` when set.
+
+### Multi-account access
+
+The proxy supports per-call AWS profile switching, allowing agents to work across multiple accounts without restarting.
+
+**Configuration:**
+
+```bash
+# Via CLI flag (first profile is default, rest are switchable)
+mcp-proxy-for-aws https://aws-mcp.us-east-1.api.aws/mcp --profile default dev staging
+
+# Via environment variable (same behavior, for plugin integration)
+AWS_MCP_PROXY_PROFILES="default dev staging" mcp-proxy-for-aws https://aws-mcp.us-east-1.api.aws/mcp
+```
+
+**How it works:**
+
+- The proxy injects an `aws_profile` parameter into auth-requiring tools (`call_aws`, `run_script`, `get_presigned_url`, `get_tasks`)
+- The agent can pass `aws_profile` on any call to route it through a specific profile's credentials
+- If `aws_profile` is omitted, the default (first) profile is used
+- Invalid profiles are rejected with an error listing allowed values
+- Each non-default profile gets its own dedicated connection to the backend
+
+**Example MCP config (Kiro):**
+
+```json
+{
+  "mcpServers": {
+    "aws": {
+      "command": "uvx",
+      "args": ["mcp-proxy-for-aws@latest", "https://aws-mcp.us-east-1.api.aws/mcp"],
+      "env": {
+        "AWS_MCP_PROXY_PROFILES": "default dev staging"
+      }
+    }
+  }
+}
 ```
 
 ### Setup Examples

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docker build -t mcp-proxy-for-aws .
 | `endpoint`	          | MCP endpoint URL (e.g., `https://your-service.us-east-1.amazonaws.com/mcp`)	                                                                                                                                                            | N/A	                                                                        |Yes	|
 | ---	                 | ---	                                                                                                                                                                                                                                    | ---	                                                                        |---	|
 | `--service`	         | AWS service name for SigV4 signing, if omitted we try to infer this from the url	                                                                                                                                                       | Inferred from endpoint if not provided	                                     |No	|
-| `--profile`	         | AWS profile(s) to use. First profile is the default. Additional profiles enable per-call switching via `aws_profile` tool parameter (e.g., `--profile default dev staging`)	| Uses `AWS_PROFILE` environment variable if not set                          |No	|
+| `--profile`	         | AWS profile(s) to use. First profile is the default. Additional profiles enable per-call switching via `aws_profile` tool parameter (e.g., `--profile prod-readonly dev staging`)	| Falls back to `AWS_PROFILE` if `--profile` and `AWS_MCP_PROXY_PROFILES` are not set |No	|
 | `--region`	          | AWS region to use	                                                                                                                                                                                                                      | Uses `AWS_REGION` environment variable if not set	                           |No	|
 | `--metadata`	        | Metadata to inject into MCP requests as key=value pairs (e.g., `--metadata KEY1=value1 KEY2=value2`)                                                                                                                                    | `AWS_REGION` is automatically injected based on `--region` if not provided    |No	|
 | `--read-only`	       | Disable tools which may require write permissions (tools which DO NOT require write permissions are annotated with [`readOnlyHint=true`](https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations-readonlyhint)) | `False`	                                                                    |No	|
@@ -128,7 +128,7 @@ export AWS_SESSION_TOKEN=<session_token>
 export AWS_REGION=<aws_region>
 
 # Multi-profile switching (alternative to --profile flag, useful for plugin integration)
-export AWS_MCP_PROXY_PROFILES="default dev staging"
+export AWS_MCP_PROXY_PROFILES="prod-readonly dev staging"
 ```
 
 > **Note:** `AWS_MCP_PROXY_PROFILES` takes precedence over `--profile` / `AWS_PROFILE` when set.
@@ -141,15 +141,15 @@ The proxy supports per-call AWS profile switching, allowing agents to work acros
 
 ```bash
 # Via CLI flag (first profile is default, rest are switchable)
-mcp-proxy-for-aws https://aws-mcp.us-east-1.api.aws/mcp --profile default dev staging
+mcp-proxy-for-aws https://aws-mcp.us-east-1.api.aws/mcp --profile prod-readonly dev staging
 
 # Via environment variable (same behavior, for plugin integration)
-AWS_MCP_PROXY_PROFILES="default dev staging" mcp-proxy-for-aws https://aws-mcp.us-east-1.api.aws/mcp
+AWS_MCP_PROXY_PROFILES="prod-readonly dev staging" mcp-proxy-for-aws https://aws-mcp.us-east-1.api.aws/mcp
 ```
 
 **How it works:**
 
-- The proxy injects an `aws_profile` parameter into auth-requiring tools (`call_aws`, `run_script`, `get_presigned_url`, `get_tasks`)
+- The proxy injects an `aws_profile` parameter into auth-requiring tools
 - The agent can pass `aws_profile` on any call to route it through a specific profile's credentials
 - If `aws_profile` is omitted, the default (first) profile is used
 - Invalid profiles are rejected with an error listing allowed values
@@ -164,7 +164,7 @@ AWS_MCP_PROXY_PROFILES="default dev staging" mcp-proxy-for-aws https://aws-mcp.u
       "command": "uvx",
       "args": ["mcp-proxy-for-aws@latest", "https://aws-mcp.us-east-1.api.aws/mcp"],
       "env": {
-        "AWS_MCP_PROXY_PROFILES": "default dev staging"
+        "AWS_MCP_PROXY_PROFILES": "prod-readonly dev staging"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docker build -t mcp-proxy-for-aws .
 | `endpoint`	          | MCP endpoint URL (e.g., `https://your-service.us-east-1.amazonaws.com/mcp`)	                                                                                                                                                            | N/A	                                                                        |Yes	|
 | ---	                 | ---	                                                                                                                                                                                                                                    | ---	                                                                        |---	|
 | `--service`	         | AWS service name for SigV4 signing, if omitted we try to infer this from the url	                                                                                                                                                       | Inferred from endpoint if not provided	                                     |No	|
-| `--profile`	         | AWS profile for AWS credentials to use	                                                                                                                                                                                                 | Uses `AWS_PROFILE` environment variable if not set                          |No	|
+| `--profile`	         | AWS profile(s) to use. First profile is the default. Additional profiles enable per-call switching via `aws_profile` tool parameter (e.g., `--profile default dev staging`) | Uses `AWS_PROFILE` environment variable if not set                          |No	|
 | `--region`	          | AWS region to use	                                                                                                                                                                                                                      | Uses `AWS_REGION` environment variable if not set	                           |No	|
 | `--metadata`	        | Metadata to inject into MCP requests as key=value pairs (e.g., `--metadata KEY1=value1 KEY2=value2`)                                                                                                                                    | `AWS_REGION` is automatically injected based on `--region` if not provided    |No	|
 | `--read-only`	       | Disable tools which may require write permissions (tools which DO NOT require write permissions are annotated with [`readOnlyHint=true`](https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations-readonlyhint)) | `False`	                                                                    |No	|
@@ -109,7 +109,6 @@ docker build -t mcp-proxy-for-aws .
 | `--write-timeout`	   | Set desired write timeout in seconds	                                                                                                                                                                                                   | 180	                                                                        |No	|
 | `--tool-timeout`	   | Maximum seconds a tool call may take before being cancelled. When set, returns a graceful error to the agent instead of hanging indefinitely	                                                                                             | 300	                                                                    |No	|
 | `--disable-telemetry` | Disables telemetry data collection                                                                                                                                                                                                      | `False`                                                                     |No	|
-| `--allow-switch-profile` | Enable per-call AWS profile switching by providing an allowlist of profile names. Each tool call can include a `profile` argument to route through a dedicated connection signed with that profile's credentials. | None (disabled) | No |
 
 ### Optional Environment Variables
 
@@ -166,14 +165,14 @@ Add the following configuration to your MCP client config file (e.g., for Kiro C
 > [!NOTE]
 > Cline users should not use `--log-level` argument because Cline checks the log messages in stderr for text "error" (case insensitive).
 
-#### Multi-account access with `--allow-switch-profile`
+#### Multi-account access
 
-The `--allow-switch-profile` flag lets individual tool calls route through different AWS profiles without restarting the proxy. This is useful when an AI agent needs to query resources across multiple AWS accounts in a single session.
+When multiple profiles are passed to `--profile`, individual tool calls can route through different AWS profiles without restarting the proxy. This is useful when an AI agent needs to query resources across multiple AWS accounts in a single session.
 
-**How it interacts with `--profile`:**
-- `--profile` sets the **default** identity used when a tool call does not specify a profile.
-- `--allow-switch-profile` defines which additional profiles a tool call may request via a `profile` argument. Each profile gets its own dedicated connection to the backend.
-- If a tool call omits `profile`, the default `--profile` connection is used. If it includes `profile`, the request is routed through the matching per-profile connection instead.
+**How it works:**
+- The first profile is the **default** identity used when a tool call does not specify a profile.
+- Additional profiles are available for per-call switching via the `aws_profile` tool parameter. Each profile gets its own dedicated connection to the backend.
+- If a tool call omits `aws_profile`, the default profile connection is used. If it includes `aws_profile`, the request is routed through the matching per-profile connection instead.
 
 ```json
 {
@@ -187,7 +186,6 @@ The `--allow-switch-profile` flag lets individual tool calls route through diffe
         "<SigV4 MCP endpoint URL>",
         "--profile",
         "default",
-        "--allow-switch-profile",
         "dev-profile",
         "staging-profile"
       ]
@@ -196,7 +194,7 @@ The `--allow-switch-profile` flag lets individual tool calls route through diffe
 }
 ```
 
-In the example above, tool calls without a `profile` argument use the `default` profile. A tool call that includes `"profile": "dev-profile"` is routed through a dedicated connection signed with `dev-profile` credentials.
+In the example above, tool calls without an `aws_profile` argument use the `default` profile. A tool call that includes `"aws_profile": "dev-profile"` is routed through a dedicated connection signed with `dev-profile` credentials.
 
 #### Using Docker
 

--- a/mcp_proxy_for_aws/cli.py
+++ b/mcp_proxy_for_aws/cli.py
@@ -174,4 +174,13 @@ Examples:
         help='Disables telemetry data collection',
     )
 
+    parser.add_argument(
+        '--allow-switch-profile',
+        nargs='+',
+        default=None,
+        metavar='PROFILE',
+        help='Enable the switch_profile tool and restrict it to the specified AWS CLI profile names '
+        '(e.g., --allow-switch-profile dev-profile staging-profile)',
+    )
+
     return parser.parse_args()

--- a/mcp_proxy_for_aws/cli.py
+++ b/mcp_proxy_for_aws/cli.py
@@ -91,8 +91,13 @@ Examples:
 
     parser.add_argument(
         '--profile',
-        help='AWS profile to use (uses AWS_PROFILE environment variable if not provided)',
-        default=os.getenv('AWS_PROFILE'),
+        nargs='+',
+        dest='profiles',
+        help='AWS profile(s) to use. First profile is the default. '
+        'Additional profiles enable per-call switching via aws_profile tool parameter '
+        '(e.g., --profile default dev staging)',
+        default=[os.getenv('AWS_PROFILE')] if os.getenv('AWS_PROFILE') else None,
+        metavar='PROFILE',
     )
 
     parser.add_argument(

--- a/mcp_proxy_for_aws/cli.py
+++ b/mcp_proxy_for_aws/cli.py
@@ -91,8 +91,13 @@ Examples:
 
     parser.add_argument(
         '--profile',
-        help='AWS profile to use (uses AWS_PROFILE environment variable if not provided)',
-        default=os.getenv('AWS_PROFILE'),
+        nargs='+',
+        dest='profiles',
+        help='AWS profile(s) to use. First profile is the default. '
+        'Additional profiles enable per-call switching via aws_profile tool parameter '
+        '(e.g., --profile default dev staging)',
+        default=[os.getenv('AWS_PROFILE')] if os.getenv('AWS_PROFILE') else None,
+        metavar='PROFILE',
     )
 
     parser.add_argument(
@@ -172,15 +177,6 @@ Examples:
         '--disable-telemetry',
         action='store_true',
         help='Disables telemetry data collection',
-    )
-
-    parser.add_argument(
-        '--allow-switch-profile',
-        nargs='+',
-        default=None,
-        metavar='PROFILE',
-        help='Enable the switch_profile tool and restrict it to the specified AWS CLI profile names '
-        '(e.g., --allow-switch-profile dev-profile staging-profile)',
     )
 
     return parser.parse_args()

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -29,8 +29,8 @@ import logging
 import mcp.types as mt
 from collections.abc import Sequence
 from fastmcp import Client
-from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools.tool import Tool, ToolResult
 from mcp_proxy_for_aws.utils import create_transport_with_sigv4
 from typing import Any, cast

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -31,7 +31,7 @@ from collections.abc import Sequence
 from fastmcp import Client
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
-from fastmcp.tools.tool import Tool, ToolResult
+from fastmcp.tools import Tool, ToolResult
 from mcp_proxy_for_aws.utils import create_transport_with_sigv4
 from typing import Any, cast
 from typing_extensions import override

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -1,0 +1,191 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Middleware that enables per-call AWS profile overrides via a ``profile`` argument.
+
+Pass ``profile`` as an extra argument on any tool call to route that single request
+through a dedicated transport signed with the specified profile's credentials. The
+argument is stripped before forwarding to the backend.
+
+Each profile gets its own lazily-created ``StreamableHttpTransport`` and MCP session,
+so parallel subagents querying different accounts don't interfere with each other.
+"""
+
+import httpx
+import logging
+import mcp.types as mt
+from collections.abc import Sequence
+from fastmcp import Client
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.tool import Tool, ToolResult
+from mcp_proxy_for_aws.utils import create_transport_with_sigv4
+from typing import Any, cast
+from typing_extensions import override
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProfileOverrideMiddleware(Middleware):
+    """Middleware that intercepts ``profile`` on any tool call for per-request AWS identity switching.
+
+    When a tool call includes a ``profile`` argument, the middleware:
+
+    1. Validates the profile against the allowed list
+    2. Strips ``profile`` from the arguments
+    3. Forwards the call through a dedicated per-profile MCP client
+
+    Each profile gets its own transport and session to the backend so that
+    requests signed with different AWS identities don't collide.
+    """
+
+    def __init__(
+        self,
+        allowed_profiles: list[str],
+        service: str,
+        region: str,
+        metadata: dict[str, Any],
+        timeout: httpx.Timeout,
+        endpoint: str,
+    ) -> None:
+        """Initialize the middleware with connection and profile configuration."""
+        super().__init__()
+        self._allowed_profiles = set(allowed_profiles)
+        self._endpoint = endpoint
+        self._service = service
+        self._region = region
+        self._metadata = metadata
+        self._timeout = timeout
+        self._profile_clients: dict[str, Client] = {}
+
+    # ── tool listing ────────────────────────────────────────────────
+
+    @override
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        """Inject ``profile`` into every tool's schema."""
+        tools = await call_next(context)
+
+        for tool in tools:
+            params = tool.parameters
+            if not isinstance(params, dict):
+                continue
+            if 'properties' not in params:
+                params['properties'] = {}
+            params['properties']['profile'] = {
+                'type': 'string',
+                'description': (
+                    'AWS CLI profile to sign this request with. Omit to use the default profile.'
+                ),
+                'enum': sorted(self._allowed_profiles),
+            }
+
+        return list(tools)
+
+    # ── tool invocation ─────────────────────────────────────────────
+
+    @override
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        """Intercept ``profile`` and route through a dedicated per-profile client."""
+        arguments = context.message.arguments
+        if isinstance(arguments, dict) and 'profile' in arguments:
+            profile = arguments['profile']
+            return await self._call_with_profile(profile, context, call_next)
+
+        return await call_next(context)
+
+    # ── internals ─────────────────────────────────────────────────
+
+    async def _get_profile_client(self, profile: str) -> Client:
+        """Get or create a dedicated MCP client for the given profile.
+
+        Each profile gets its own ``StreamableHttpTransport`` and MCP session
+        so that requests signed with different AWS identities don't collide
+        on the same backend session.
+        """
+        if profile not in self._profile_clients:
+            logger.info('Creating dedicated connection for profile %s', profile)
+            transport = create_transport_with_sigv4(
+                self._endpoint,
+                self._service,
+                self._region,
+                self._metadata,
+                self._timeout,
+                profile,
+            )
+            client = Client(transport=transport)
+            await client.__aenter__()
+            self._profile_clients[profile] = client
+        return self._profile_clients[profile]
+
+    async def disconnect_profile_clients(self) -> None:
+        """Disconnect all per-profile clients. Call during server shutdown."""
+        for profile, client in self._profile_clients.items():
+            try:
+                await client.__aexit__(None, None, None)
+            except Exception:
+                logger.exception('Failed to disconnect profile client %s', profile)
+        self._profile_clients.clear()
+
+    async def _call_with_profile(
+        self,
+        profile: str,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        """Forward a tool call through a dedicated per-profile connection."""
+        if profile not in self._allowed_profiles:
+            allowed = ', '.join(sorted(self._allowed_profiles))
+            return ToolResult(
+                content=f'Error: profile {profile!r} is not in the allowed list. '
+                f'Allowed profiles: {allowed}'
+            )
+
+        # Strip profile before forwarding to the backend
+        arguments: dict[str, Any] = dict(cast(dict[str, Any], context.message.arguments))
+        arguments.pop('profile', None)
+
+        logger.info(
+            'Per-call profile override: routing through dedicated connection for %s', profile
+        )
+
+        try:
+            client = await self._get_profile_client(profile)
+        except Exception:
+            logger.exception('Failed to create connection for profile %s', profile)
+            return ToolResult(
+                content=f'Error: failed to create connection for profile {profile!r}. '
+                'Check that the profile is configured and credentials are valid.'
+            )
+
+        try:
+            result = await client.call_tool(context.message.name, arguments)
+            return ToolResult(
+                content=result.content,
+                structured_content=result.structured_content,
+                meta=result.meta,
+            )
+        except Exception:
+            logger.exception('Error calling tool via profile %s', profile)
+            return ToolResult(
+                content=f'Error: tool call failed using profile {profile!r}. '
+                'The request could not be completed with the specified profile.'
+            )

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -22,6 +22,7 @@ Each profile gets its own lazily-created ``StreamableHttpTransport`` and MCP ses
 so parallel subagents querying different accounts don't interfere with each other.
 """
 
+import asyncio
 import httpx
 import logging
 import mcp.types as mt
@@ -68,6 +69,7 @@ class ProfileOverrideMiddleware(Middleware):
         self._metadata = metadata
         self._timeout = timeout
         self._profile_clients: dict[str, Client] = {}
+        self._lock = asyncio.Lock()
 
     # ── tool listing ────────────────────────────────────────────────
 
@@ -121,20 +123,21 @@ class ProfileOverrideMiddleware(Middleware):
         so that requests signed with different AWS identities don't collide
         on the same backend session.
         """
-        if profile not in self._profile_clients:
-            logger.info('Creating dedicated connection for profile %s', profile)
-            transport = create_transport_with_sigv4(
-                self._endpoint,
-                self._service,
-                self._region,
-                self._metadata,
-                self._timeout,
-                profile,
-            )
-            client = Client(transport=transport)
-            await client.__aenter__()
-            self._profile_clients[profile] = client
-        return self._profile_clients[profile]
+        async with self._lock:
+            if profile not in self._profile_clients:
+                logger.info('Creating dedicated connection for profile %s', profile)
+                transport = create_transport_with_sigv4(
+                    self._endpoint,
+                    self._service,
+                    self._region,
+                    self._metadata,
+                    self._timeout,
+                    profile,
+                )
+                client = Client(transport=transport)
+                await client.__aenter__()
+                self._profile_clients[profile] = client
+            return self._profile_clients[profile]
 
     async def disconnect_profile_clients(self) -> None:
         """Disconnect all per-profile clients. Call during server shutdown."""

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -168,8 +168,7 @@ class ProfileOverrideMiddleware(Middleware):
         if profile not in self._allowed_profiles:
             allowed = ', '.join(sorted(self._allowed_profiles))
             raise ToolError(
-                f'Profile {profile!r} is not in the allowed list. '
-                f'Allowed profiles: {allowed}'
+                f'Profile {profile!r} is not in the allowed list. Allowed profiles: {allowed}'
             )
 
         # Strip proxy_profile before forwarding to the backend

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Middleware that enables per-call AWS profile overrides via a ``profile`` argument.
+"""Middleware that enables per-call AWS profile overrides via a ``proxy_profile`` argument.
 
-Pass ``profile`` as an extra argument on any tool call to route that single request
+Pass ``proxy_profile`` as an extra argument on any tool call to route that single request
 through a dedicated transport signed with the specified profile's credentials. The
 argument is stripped before forwarding to the backend.
 
@@ -23,12 +23,14 @@ so parallel subagents querying different accounts don't interfere with each othe
 """
 
 import asyncio
+import copy
 import httpx
 import logging
 import mcp.types as mt
 from collections.abc import Sequence
 from fastmcp import Client
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import Tool, ToolResult
 from mcp_proxy_for_aws.utils import create_transport_with_sigv4
 from typing import Any, cast
@@ -39,12 +41,12 @@ logger = logging.getLogger(__name__)
 
 
 class ProfileOverrideMiddleware(Middleware):
-    """Middleware that intercepts ``profile`` on any tool call for per-request AWS identity switching.
+    """Middleware that intercepts ``proxy_profile`` on any tool call for per-request AWS identity switching.
 
-    When a tool call includes a ``profile`` argument, the middleware:
+    When a tool call includes a ``proxy_profile`` argument, the middleware:
 
     1. Validates the profile against the allowed list
-    2. Strips ``profile`` from the arguments
+    2. Strips ``proxy_profile`` from the arguments
     3. Forwards the call through a dedicated per-profile MCP client
 
     Each profile gets its own transport and session to the backend so that
@@ -79,22 +81,24 @@ class ProfileOverrideMiddleware(Middleware):
         context: MiddlewareContext[mt.ListToolsRequest],
         call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
     ) -> Sequence[Tool]:
-        """Inject ``profile`` into every tool's schema."""
+        """Inject ``proxy_profile`` into every tool's schema."""
         tools = await call_next(context)
 
         for tool in tools:
-            params = tool.parameters
-            if not isinstance(params, dict):
+            if not isinstance(tool.parameters, dict):
                 continue
+            # Deep-copy to avoid mutating upstream cached/shared dicts
+            params = copy.deepcopy(tool.parameters)
             if 'properties' not in params:
                 params['properties'] = {}
-            params['properties']['profile'] = {
+            params['properties']['proxy_profile'] = {
                 'type': 'string',
                 'description': (
                     'AWS CLI profile to sign this request with. Omit to use the default profile.'
                 ),
                 'enum': sorted(self._allowed_profiles),
             }
+            tool.parameters = params
 
         return list(tools)
 
@@ -106,10 +110,10 @@ class ProfileOverrideMiddleware(Middleware):
         context: MiddlewareContext[mt.CallToolRequestParams],
         call_next: CallNext[mt.CallToolRequestParams, ToolResult],
     ) -> ToolResult:
-        """Intercept ``profile`` and route through a dedicated per-profile client."""
+        """Intercept ``proxy_profile`` and route through a dedicated per-profile client."""
         arguments = context.message.arguments
-        if isinstance(arguments, dict) and 'profile' in arguments:
-            profile = arguments['profile']
+        if isinstance(arguments, dict) and 'proxy_profile' in arguments:
+            profile = arguments['proxy_profile']
             return await self._call_with_profile(profile, context, call_next)
 
         return await call_next(context)
@@ -157,14 +161,14 @@ class ProfileOverrideMiddleware(Middleware):
         """Forward a tool call through a dedicated per-profile connection."""
         if profile not in self._allowed_profiles:
             allowed = ', '.join(sorted(self._allowed_profiles))
-            return ToolResult(
-                content=f'Error: profile {profile!r} is not in the allowed list. '
+            raise ToolError(
+                f'Profile {profile!r} is not in the allowed list. '
                 f'Allowed profiles: {allowed}'
             )
 
-        # Strip profile before forwarding to the backend
+        # Strip proxy_profile before forwarding to the backend
         arguments: dict[str, Any] = dict(cast(dict[str, Any], context.message.arguments))
-        arguments.pop('profile', None)
+        arguments.pop('proxy_profile', None)
 
         logger.info(
             'Per-call profile override: routing through dedicated connection for %s', profile
@@ -174,8 +178,8 @@ class ProfileOverrideMiddleware(Middleware):
             client = await self._get_profile_client(profile)
         except Exception:
             logger.exception('Failed to create connection for profile %s', profile)
-            return ToolResult(
-                content=f'Error: failed to create connection for profile {profile!r}. '
+            raise ToolError(
+                f'Failed to create connection for profile {profile!r}. '
                 'Check that the profile is configured and credentials are valid.'
             )
 
@@ -188,7 +192,7 @@ class ProfileOverrideMiddleware(Middleware):
             )
         except Exception:
             logger.exception('Error calling tool via profile %s', profile)
-            return ToolResult(
-                content=f'Error: tool call failed using profile {profile!r}. '
+            raise ToolError(
+                f'Tool call failed using profile {profile!r}. '
                 'The request could not be completed with the specified profile.'
             )

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -91,6 +91,12 @@ class ProfileOverrideMiddleware(Middleware):
             params = copy.deepcopy(tool.parameters)
             if 'properties' not in params:
                 params['properties'] = {}
+            if 'proxy_profile' in params['properties']:
+                logger.warning(
+                    'Tool %r already defines a "proxy_profile" parameter; '
+                    'the middleware override is shadowing the backend definition.',
+                    tool.name,
+                )
             params['properties']['proxy_profile'] = {
                 'type': 'string',
                 'description': (

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -1,0 +1,234 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Middleware that enables per-call AWS profile overrides via a ``aws_profile`` argument.
+
+Pass ``aws_profile`` as an extra argument on any auth-requiring tool call to route
+that single request through a dedicated transport signed with the specified profile's
+credentials. The argument is stripped before forwarding to the backend.
+
+Each non-default profile gets its own lazily-created ``StreamableHttpTransport`` and MCP
+session, so parallel subagents querying different accounts don't interfere with each other.
+When the default profile is specified explicitly, the call is routed through the normal
+middleware chain (no duplicate connection).
+"""
+
+import asyncio
+import copy
+import httpx
+import logging
+import mcp.types as mt
+from collections.abc import Sequence
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools import Tool, ToolResult
+from mcp_proxy_for_aws.utils import create_transport_with_sigv4
+from typing import Any, cast
+from typing_extensions import override
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProfileOverrideMiddleware(Middleware):
+    """Middleware that intercepts ``aws_profile`` on any tool call for per-request AWS identity switching.
+
+    When a tool call includes a ``aws_profile`` argument, the middleware:
+
+    1. Validates the profile against the allowed list
+    2. Strips ``aws_profile`` from the arguments
+    3. Forwards the call through a dedicated per-profile MCP client
+
+    Each profile gets its own transport and session to the backend so that
+    requests signed with different AWS identities don't collide.
+    """
+
+    def __init__(
+        self,
+        allowed_profiles: list[str],
+        default_profile: str,
+        service: str,
+        region: str,
+        metadata: dict[str, Any],
+        timeout: httpx.Timeout,
+        endpoint: str,
+    ) -> None:
+        """Initialize the middleware with connection and profile configuration."""
+        super().__init__()
+        self._allowed_profiles = set(allowed_profiles)
+        self._default_profile = default_profile
+        self._endpoint = endpoint
+        self._service = service
+        self._region = region
+        self._metadata = metadata
+        self._timeout = timeout
+        self._profile_clients: dict[str, Client] = {}
+        self._lock = asyncio.Lock()
+
+    # Tools that require AWS authentication and support profile switching
+    AUTH_REQUIRING_TOOLS = {
+        'aws___call_aws',
+        'aws___run_script',
+        'aws___get_presigned_url',
+        'aws___get_tasks',
+    }
+
+    # ── tool listing ────────────────────────────────────────────────
+
+    @override
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        """Inject ``aws_profile`` into auth-requiring tools' schemas only."""
+        tools = await call_next(context)
+
+        for tool in tools:
+            if tool.name not in self.AUTH_REQUIRING_TOOLS:
+                continue
+            if not isinstance(tool.parameters, dict):
+                continue
+            # Deep-copy to avoid mutating upstream cached/shared dicts
+            params = copy.deepcopy(tool.parameters)
+            if 'properties' not in params:
+                params['properties'] = {}
+            if 'aws_profile' in params['properties']:
+                logger.warning(
+                    'Tool %r already defines a "aws_profile" parameter; '
+                    'the middleware override is shadowing the backend definition.',
+                    tool.name,
+                )
+            params['properties']['aws_profile'] = {
+                'type': 'string',
+                'description': (
+                    'AWS CLI profile to sign this request with. '
+                    'Available profiles: ' + ', '.join(sorted(self._allowed_profiles)) + '.'
+                ),
+                'enum': sorted(self._allowed_profiles),
+            }
+            tool.parameters = params
+
+        return list(tools)
+
+    # ── tool invocation ─────────────────────────────────────────────
+
+    @override
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        """Intercept ``aws_profile`` and route through a dedicated per-profile client."""
+        arguments = context.message.arguments
+        if isinstance(arguments, dict) and 'aws_profile' in arguments:
+            profile = arguments['aws_profile']
+            return await self._call_with_profile(profile, context, call_next)
+
+        return await call_next(context)
+
+    # ── internals ─────────────────────────────────────────────────
+
+    async def _get_profile_client(self, profile: str) -> Client:
+        """Get or create a dedicated MCP client for the given profile.
+
+        Each profile gets its own ``StreamableHttpTransport`` and MCP session
+        so that requests signed with different AWS identities don't collide
+        on the same backend session.
+        """
+        async with self._lock:
+            if profile not in self._profile_clients:
+                logger.info('Creating dedicated connection for profile %s', profile)
+                transport = create_transport_with_sigv4(
+                    self._endpoint,
+                    self._service,
+                    self._region,
+                    self._metadata,
+                    self._timeout,
+                    profile,
+                )
+                client = Client(transport=transport)
+                await client.__aenter__()
+                self._profile_clients[profile] = client
+            return self._profile_clients[profile]
+
+    async def disconnect_profile_clients(self) -> None:
+        """Disconnect all per-profile clients. Call during server shutdown."""
+        for profile, client in self._profile_clients.items():
+            try:
+                await client.__aexit__(None, None, None)
+            except Exception:
+                logger.exception('Failed to disconnect profile client %s', profile)
+        self._profile_clients.clear()
+
+    async def _call_with_profile(
+        self,
+        profile: str,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        """Forward a tool call through a dedicated per-profile connection."""
+        if profile not in self._allowed_profiles:
+            allowed = ', '.join(sorted(self._allowed_profiles))
+            raise ToolError(
+                f'Profile {profile!r} is not in the allowed list. Allowed profiles: {allowed}'
+            )
+
+        # Strip aws_profile before forwarding to the backend
+        arguments: dict[str, Any] = dict(cast(dict[str, Any], context.message.arguments))
+        arguments.pop('aws_profile', None)
+
+        # If it's the default profile, route through the normal middleware chain.
+        # This reuses the existing default client (no duplicate connection)
+        # and preserves retry middleware behavior.
+        if profile == self._default_profile:
+            context.message.arguments = arguments
+            return await call_next(context)
+
+        logger.info(
+            'Per-call profile override: routing through dedicated connection for %s', profile
+        )
+
+        try:
+            client = await self._get_profile_client(profile)
+        except Exception as e:
+            logger.exception('Failed to create connection for profile %s', profile)
+            raise ToolError(
+                f'Failed to create connection for profile {profile!r}. '
+                'Check that the profile is configured and credentials are valid.'
+            ) from e
+
+        try:
+            result = await client.call_tool(context.message.name, arguments, raise_on_error=False)
+            if result.is_error:
+                # Propagate the backend error message to the agent
+                error_text = ''
+                for block in result.content:
+                    if hasattr(block, 'text'):
+                        error_text += block.text  # type: ignore[union-attr]
+                raise ToolError(error_text or f'Tool call failed using profile {profile!r}.')
+            return ToolResult(
+                content=result.content,
+                structured_content=result.structured_content,
+                meta=result.meta,
+            )
+        except ToolError:
+            raise
+        except Exception as e:
+            logger.exception('Error calling tool via profile %s', profile)
+            raise ToolError(
+                f'Tool call failed using profile {profile!r}. '
+                'The request could not be completed with the specified profile.'
+            ) from e

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -64,6 +64,8 @@ class ProfileOverrideMiddleware(Middleware):
         metadata: dict[str, Any],
         timeout: httpx.Timeout,
         endpoint: str,
+        disable_telemetry: bool = False,
+        skip_auth: bool = False,
     ) -> None:
         """Initialize the middleware with connection and profile configuration."""
         super().__init__()
@@ -74,6 +76,8 @@ class ProfileOverrideMiddleware(Middleware):
         self._region = region
         self._metadata = metadata
         self._timeout = timeout
+        self._disable_telemetry = disable_telemetry
+        self._skip_auth = skip_auth
         self._profile_clients: dict[str, Client] = {}
         self._lock = asyncio.Lock()
 
@@ -82,6 +86,7 @@ class ProfileOverrideMiddleware(Middleware):
         'aws___call_aws',
         'aws___run_script',
         'aws___get_presigned_url',
+        'aws___get_tasks',
         'aws___suggest_aws_commands',
     }
 
@@ -134,6 +139,13 @@ class ProfileOverrideMiddleware(Middleware):
         """Intercept ``aws_profile`` and route through a dedicated per-profile client."""
         arguments = context.message.arguments
         if isinstance(arguments, dict) and 'aws_profile' in arguments:
+            # Only process aws_profile for auth-requiring tools.
+            # If an agent hallucinates the parameter on a non-auth tool,
+            # strip it silently and route through the normal path.
+            if context.message.name not in self.AUTH_REQUIRING_TOOLS:
+                logger.warning('Ignoring aws_profile on non-auth tool %r', context.message.name)
+                arguments.pop('aws_profile', None)
+                return await call_next(context)
             profile = arguments['aws_profile']
             return await self._call_with_profile(profile, context, call_next)
 
@@ -158,6 +170,8 @@ class ProfileOverrideMiddleware(Middleware):
                     self._metadata,
                     self._timeout,
                     profile,
+                    self._disable_telemetry,
+                    self._skip_auth,
                 )
                 client = Client(transport=transport)
                 await client.__aenter__()

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -82,7 +82,7 @@ class ProfileOverrideMiddleware(Middleware):
         'aws___call_aws',
         'aws___run_script',
         'aws___get_presigned_url',
-        'aws___get_tasks',
+        'aws___suggest_aws_commands',
     }
 
     # ── tool listing ────────────────────────────────────────────────

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Middleware that enables per-call AWS profile overrides via a ``proxy_profile`` argument.
+"""Middleware that enables per-call AWS profile overrides via an ``aws_profile`` argument.
 
-Pass ``proxy_profile`` as an extra argument on any tool call to route that single request
+Pass ``aws_profile`` as an extra argument on any tool call to route that single request
 through a dedicated transport signed with the specified profile's credentials. The
 argument is stripped before forwarding to the backend.
 
@@ -41,12 +41,12 @@ logger = logging.getLogger(__name__)
 
 
 class ProfileOverrideMiddleware(Middleware):
-    """Middleware that intercepts ``proxy_profile`` on any tool call for per-request AWS identity switching.
+    """Middleware that intercepts ``aws_profile`` on any tool call for per-request AWS identity switching.
 
-    When a tool call includes a ``proxy_profile`` argument, the middleware:
+    When a tool call includes an ``aws_profile`` argument, the middleware:
 
     1. Validates the profile against the allowed list
-    2. Strips ``proxy_profile`` from the arguments
+    2. Strips ``aws_profile`` from the arguments
     3. Forwards the call through a dedicated per-profile MCP client
 
     Each profile gets its own transport and session to the backend so that
@@ -81,7 +81,7 @@ class ProfileOverrideMiddleware(Middleware):
         context: MiddlewareContext[mt.ListToolsRequest],
         call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
     ) -> Sequence[Tool]:
-        """Inject ``proxy_profile`` into every tool's schema."""
+        """Inject ``aws_profile`` into every tool's schema."""
         tools = await call_next(context)
 
         for tool in tools:
@@ -91,13 +91,13 @@ class ProfileOverrideMiddleware(Middleware):
             params = copy.deepcopy(tool.parameters)
             if 'properties' not in params:
                 params['properties'] = {}
-            if 'proxy_profile' in params['properties']:
+            if 'aws_profile' in params['properties']:
                 logger.warning(
-                    'Tool %r already defines a "proxy_profile" parameter; '
+                    'Tool %r already defines an "aws_profile" parameter; '
                     'the middleware override is shadowing the backend definition.',
                     tool.name,
                 )
-            params['properties']['proxy_profile'] = {
+            params['properties']['aws_profile'] = {
                 'type': 'string',
                 'description': (
                     'AWS CLI profile to sign this request with. Omit to use the default profile.'
@@ -116,10 +116,10 @@ class ProfileOverrideMiddleware(Middleware):
         context: MiddlewareContext[mt.CallToolRequestParams],
         call_next: CallNext[mt.CallToolRequestParams, ToolResult],
     ) -> ToolResult:
-        """Intercept ``proxy_profile`` and route through a dedicated per-profile client."""
+        """Intercept ``aws_profile`` and route through a dedicated per-profile client."""
         arguments = context.message.arguments
-        if isinstance(arguments, dict) and 'proxy_profile' in arguments:
-            profile = arguments['proxy_profile']
+        if isinstance(arguments, dict) and 'aws_profile' in arguments:
+            profile = arguments['aws_profile']
             return await self._call_with_profile(profile, context, call_next)
 
         return await call_next(context)
@@ -171,9 +171,9 @@ class ProfileOverrideMiddleware(Middleware):
                 f'Profile {profile!r} is not in the allowed list. Allowed profiles: {allowed}'
             )
 
-        # Strip proxy_profile before forwarding to the backend
+        # Strip aws_profile before forwarding to the backend
         arguments: dict[str, Any] = dict(cast(dict[str, Any], context.message.arguments))
-        arguments.pop('proxy_profile', None)
+        arguments.pop('aws_profile', None)
 
         logger.info(
             'Per-call profile override: routing through dedicated connection for %s', profile

--- a/mcp_proxy_for_aws/server.py
+++ b/mcp_proxy_for_aws/server.py
@@ -105,17 +105,9 @@ async def run_proxy(args) -> None:
         add_logging_middleware(proxy, args.log_level)
         add_tool_filtering_middleware(proxy, args.read_only)
 
-        allowed_profiles = getattr(args, 'allow_switch_profile', None)
-        if isinstance(allowed_profiles, list) and allowed_profiles:
-            profile_middleware = ProfileOverrideMiddleware(
-                allowed_profiles=allowed_profiles,
-                service=service,
-                region=region,
-                metadata=metadata,
-                timeout=timeout,
-                endpoint=args.endpoint,
-            )
-            proxy.add_middleware(profile_middleware)
+        profile_middleware = add_profile_override_middleware(
+            proxy, args, service, region, metadata, timeout
+        )
 
         if args.retries:
             add_retry_middleware(proxy, args.retries)
@@ -138,6 +130,43 @@ def add_tool_error_middleware(mcp: FastMCP, tool_timeout: float) -> None:
     """
     logger.info('Adding tool error middleware with tool_timeout=%s', tool_timeout)
     mcp.add_middleware(ToolErrorMiddleware(tool_call_timeout=tool_timeout))
+
+
+def add_profile_override_middleware(
+    mcp: FastMCP,
+    args,
+    service: str,
+    region: str,
+    metadata: dict,
+    timeout: httpx.Timeout,
+) -> ProfileOverrideMiddleware | None:
+    """Add profile override middleware to target MCP server.
+
+    Args:
+        mcp: The FastMCP instance to add profile override to
+        args: The parsed CLI arguments
+        service: The AWS service name
+        region: The AWS region
+        metadata: The metadata dictionary
+        timeout: The httpx timeout configuration
+
+    Returns:
+        The ProfileOverrideMiddleware instance if added, None otherwise
+    """
+    allowed_profiles = getattr(args, 'allow_switch_profile', None)
+    if not isinstance(allowed_profiles, list) or not allowed_profiles:
+        return None
+    logger.info('Adding profile override middleware')
+    middleware = ProfileOverrideMiddleware(
+        allowed_profiles=allowed_profiles,
+        service=service,
+        region=region,
+        metadata=metadata,
+        timeout=timeout,
+        endpoint=args.endpoint,
+    )
+    mcp.add_middleware(middleware)
+    return middleware
 
 
 def add_tool_filtering_middleware(mcp: FastMCP, read_only: bool = False) -> None:

--- a/mcp_proxy_for_aws/server.py
+++ b/mcp_proxy_for_aws/server.py
@@ -33,6 +33,7 @@ from mcp_proxy_for_aws import __version__
 from mcp_proxy_for_aws.cli import parse_args
 from mcp_proxy_for_aws.logging_config import configure_logging
 from mcp_proxy_for_aws.middleware.initialize_middleware import InitializeMiddleware
+from mcp_proxy_for_aws.middleware.profile_switcher import ProfileOverrideMiddleware
 from mcp_proxy_for_aws.middleware.tool_error_middleware import ToolErrorMiddleware
 from mcp_proxy_for_aws.middleware.tool_filter import ToolFilteringMiddleware
 from mcp_proxy_for_aws.proxy import AWSMCPProxyClientFactory
@@ -88,6 +89,7 @@ async def run_proxy(args) -> None:
     )
     client_factory = AWSMCPProxyClientFactory(transport)
 
+    profile_middleware: ProfileOverrideMiddleware | None = None
     try:
         proxy = FastMCPProxy(
             client_factory=client_factory,
@@ -103,6 +105,18 @@ async def run_proxy(args) -> None:
         add_logging_middleware(proxy, args.log_level)
         add_tool_filtering_middleware(proxy, args.read_only)
 
+        allowed_profiles = getattr(args, 'allow_switch_profile', None)
+        if isinstance(allowed_profiles, list) and allowed_profiles:
+            profile_middleware = ProfileOverrideMiddleware(
+                allowed_profiles=allowed_profiles,
+                service=service,
+                region=region,
+                metadata=metadata,
+                timeout=timeout,
+                endpoint=args.endpoint,
+            )
+            proxy.add_middleware(profile_middleware)
+
         if args.retries:
             add_retry_middleware(proxy, args.retries)
         await proxy.run_async(transport='stdio', show_banner=False, log_level=args.log_level)
@@ -110,6 +124,8 @@ async def run_proxy(args) -> None:
         logger.error('Cannot start proxy server: %s', e)
         raise e
     finally:
+        if profile_middleware:
+            await profile_middleware.disconnect_profile_clients()
         await client_factory.disconnect()
 
 

--- a/mcp_proxy_for_aws/server.py
+++ b/mcp_proxy_for_aws/server.py
@@ -65,8 +65,11 @@ async def run_proxy(args) -> None:
     if args.metadata:
         metadata.update(args.metadata)
 
-    # Get profile(s) from CLI args or env var
-    # AWS_MCP_PROXY_PROFILES takes precedence over --profile/AWS_PROFILE
+    # Get profile(s) from CLI args or env var.
+    # AWS_MCP_PROXY_PROFILES: Space-separated list of AWS profile names for multi-account
+    # support. The first profile is the default; additional profiles are available for
+    # per-call override via the aws_profile tool parameter. Takes precedence over
+    # --profile / AWS_PROFILE to allow runtime configuration without CLI changes.
     env_profiles = os.environ.get('AWS_MCP_PROXY_PROFILES')
     if env_profiles:
         profiles = env_profiles.split()
@@ -85,7 +88,7 @@ async def run_proxy(args) -> None:
         region,
         metadata,
         default_profile,
-        all_profiles[1:] if len(all_profiles) > 1 else [],
+        all_profiles[1:],
     )
 
     timeout = httpx.Timeout(
@@ -125,7 +128,16 @@ async def run_proxy(args) -> None:
         add_tool_filtering_middleware(proxy, args.read_only)
 
         profile_middleware = add_profile_override_middleware(
-            proxy, all_profiles, default_profile, service, region, metadata, timeout, args.endpoint
+            proxy,
+            all_profiles,
+            default_profile,
+            service,
+            region,
+            metadata,
+            timeout,
+            args.endpoint,
+            args.disable_telemetry,
+            args.skip_auth,
         )
 
         if args.retries:
@@ -160,6 +172,8 @@ def add_profile_override_middleware(
     metadata: dict,
     timeout: httpx.Timeout,
     endpoint: str,
+    disable_telemetry: bool = False,
+    skip_auth: bool = False,
 ) -> ProfileOverrideMiddleware | None:
     """Add profile override middleware to target MCP server.
 
@@ -172,6 +186,8 @@ def add_profile_override_middleware(
         metadata: The metadata dictionary
         timeout: The httpx timeout configuration
         endpoint: The MCP endpoint URL
+        disable_telemetry: Whether to disable telemetry on profile transports
+        skip_auth: Whether to skip signing when credentials are unavailable
 
     Returns:
         The ProfileOverrideMiddleware instance if added, None otherwise
@@ -189,6 +205,8 @@ def add_profile_override_middleware(
         metadata=metadata,
         timeout=timeout,
         endpoint=endpoint,
+        disable_telemetry=disable_telemetry,
+        skip_auth=skip_auth,
     )
     mcp.add_middleware(middleware)
     return middleware

--- a/mcp_proxy_for_aws/server.py
+++ b/mcp_proxy_for_aws/server.py
@@ -178,7 +178,8 @@ def add_profile_override_middleware(
     """
     if len(all_profiles) < 2:
         return None
-    assert default_profile is not None
+    if default_profile is None:
+        return None
     logger.info('Adding profile override middleware with profiles: %s', all_profiles)
     middleware = ProfileOverrideMiddleware(
         allowed_profiles=all_profiles,

--- a/mcp_proxy_for_aws/server.py
+++ b/mcp_proxy_for_aws/server.py
@@ -25,6 +25,7 @@ This server provides a unified interface to backend servers by:
 import asyncio
 import httpx
 import logging
+import os
 from fastmcp.server.middleware.error_handling import RetryMiddleware
 from fastmcp.server.middleware.logging import LoggingMiddleware
 from fastmcp.server.providers.proxy import FastMCPProxy
@@ -33,6 +34,7 @@ from mcp_proxy_for_aws import __version__
 from mcp_proxy_for_aws.cli import parse_args
 from mcp_proxy_for_aws.logging_config import configure_logging
 from mcp_proxy_for_aws.middleware.initialize_middleware import InitializeMiddleware
+from mcp_proxy_for_aws.middleware.profile_switcher import ProfileOverrideMiddleware
 from mcp_proxy_for_aws.middleware.tool_error_middleware import ToolErrorMiddleware
 from mcp_proxy_for_aws.middleware.tool_filter import ToolFilteringMiddleware
 from mcp_proxy_for_aws.proxy import AWSMCPProxyClientFactory
@@ -63,16 +65,27 @@ async def run_proxy(args) -> None:
     if args.metadata:
         metadata.update(args.metadata)
 
-    # Get profile
-    profile = args.profile
+    # Get profile(s) from CLI args or env var
+    # AWS_MCP_PROXY_PROFILES takes precedence over --profile/AWS_PROFILE
+    env_profiles = os.environ.get('AWS_MCP_PROXY_PROFILES')
+    if env_profiles:
+        profiles = env_profiles.split()
+    elif args.profiles:
+        profiles = args.profiles
+    else:
+        profiles = []
+    default_profile = profiles[0] if profiles else None
+    # Dedup profiles, preserve order, include all (including default)
+    all_profiles = list(dict.fromkeys(profiles))
 
     # Log server configuration
     logger.info(
-        'Using service: %s, region: %s, metadata: %s, profile: %s',
+        'Using service: %s, region: %s, metadata: %s, profile: %s, switch profiles: %s',
         service,
         region,
         metadata,
-        profile,
+        default_profile,
+        all_profiles[1:] if len(all_profiles) > 1 else [],
     )
 
     timeout = httpx.Timeout(
@@ -89,12 +102,13 @@ async def run_proxy(args) -> None:
         region,
         metadata,
         timeout,
-        profile,
+        default_profile,
         args.disable_telemetry,
         args.skip_auth,
     )
     client_factory = AWSMCPProxyClientFactory(transport)
 
+    profile_middleware: ProfileOverrideMiddleware | None = None
     try:
         proxy = FastMCPProxy(
             client_factory=client_factory,
@@ -110,6 +124,10 @@ async def run_proxy(args) -> None:
         add_logging_middleware(proxy, args.log_level)
         add_tool_filtering_middleware(proxy, args.read_only)
 
+        profile_middleware = add_profile_override_middleware(
+            proxy, all_profiles, default_profile, service, region, metadata, timeout, args.endpoint
+        )
+
         if args.retries:
             add_retry_middleware(proxy, args.retries)
         await proxy.run_async(transport='stdio', show_banner=False, log_level=args.log_level)
@@ -117,6 +135,8 @@ async def run_proxy(args) -> None:
         logger.error('Cannot start proxy server: %s', e)
         raise e
     finally:
+        if profile_middleware:
+            await profile_middleware.disconnect_profile_clients()
         await client_factory.disconnect()
 
 
@@ -129,6 +149,48 @@ def add_tool_error_middleware(mcp: FastMCP, tool_timeout: float) -> None:
     """
     logger.info('Adding tool error middleware with tool_timeout=%s', tool_timeout)
     mcp.add_middleware(ToolErrorMiddleware(tool_call_timeout=tool_timeout))
+
+
+def add_profile_override_middleware(
+    mcp: FastMCP,
+    all_profiles: list[str],
+    default_profile: str | None,
+    service: str,
+    region: str,
+    metadata: dict,
+    timeout: httpx.Timeout,
+    endpoint: str,
+) -> ProfileOverrideMiddleware | None:
+    """Add profile override middleware to target MCP server.
+
+    Args:
+        mcp: The FastMCP instance to add profile override to
+        all_profiles: List of all allowed profiles (including default)
+        default_profile: The default profile name (first in the list)
+        service: The AWS service name
+        region: The AWS region
+        metadata: The metadata dictionary
+        timeout: The httpx timeout configuration
+        endpoint: The MCP endpoint URL
+
+    Returns:
+        The ProfileOverrideMiddleware instance if added, None otherwise
+    """
+    if len(all_profiles) < 2:
+        return None
+    assert default_profile is not None
+    logger.info('Adding profile override middleware with profiles: %s', all_profiles)
+    middleware = ProfileOverrideMiddleware(
+        allowed_profiles=all_profiles,
+        default_profile=default_profile,
+        service=service,
+        region=region,
+        metadata=metadata,
+        timeout=timeout,
+        endpoint=endpoint,
+    )
+    mcp.add_middleware(middleware)
+    return middleware
 
 
 def add_tool_filtering_middleware(mcp: FastMCP, read_only: bool = False) -> None:

--- a/mcp_proxy_for_aws/server.py
+++ b/mcp_proxy_for_aws/server.py
@@ -64,8 +64,11 @@ async def run_proxy(args) -> None:
     if args.metadata:
         metadata.update(args.metadata)
 
-    # Get profile
-    profile = args.profile
+    # Get profile(s)
+    profiles: list[str] = args.profiles if args.profiles else []
+    default_profile = profiles[0] if profiles else None
+    # Dedup switch profiles and exclude the default profile
+    switch_profiles = list(dict.fromkeys(p for p in profiles[1:] if p != default_profile))
 
     # Log server configuration
     logger.info(
@@ -73,7 +76,7 @@ async def run_proxy(args) -> None:
         service,
         region,
         metadata,
-        profile,
+        default_profile,
     )
 
     timeout = httpx.Timeout(
@@ -85,7 +88,7 @@ async def run_proxy(args) -> None:
 
     # Create transport with SigV4 authentication
     transport = create_transport_with_sigv4(
-        args.endpoint, service, region, metadata, timeout, profile, args.disable_telemetry
+        args.endpoint, service, region, metadata, timeout, default_profile, args.disable_telemetry
     )
     client_factory = AWSMCPProxyClientFactory(transport)
 
@@ -106,7 +109,7 @@ async def run_proxy(args) -> None:
         add_tool_filtering_middleware(proxy, args.read_only)
 
         profile_middleware = add_profile_override_middleware(
-            proxy, args, service, region, metadata, timeout
+            proxy, switch_profiles, service, region, metadata, timeout, args.endpoint
         )
 
         if args.retries:
@@ -134,36 +137,37 @@ def add_tool_error_middleware(mcp: FastMCP, tool_timeout: float) -> None:
 
 def add_profile_override_middleware(
     mcp: FastMCP,
-    args,
+    switch_profiles: list[str],
     service: str,
     region: str,
     metadata: dict,
     timeout: httpx.Timeout,
+    endpoint: str,
 ) -> ProfileOverrideMiddleware | None:
     """Add profile override middleware to target MCP server.
 
     Args:
         mcp: The FastMCP instance to add profile override to
-        args: The parsed CLI arguments
+        switch_profiles: List of additional profiles the agent can switch to
         service: The AWS service name
         region: The AWS region
         metadata: The metadata dictionary
         timeout: The httpx timeout configuration
+        endpoint: The MCP endpoint URL
 
     Returns:
         The ProfileOverrideMiddleware instance if added, None otherwise
     """
-    allowed_profiles = getattr(args, 'allow_switch_profile', None)
-    if not isinstance(allowed_profiles, list) or not allowed_profiles:
+    if not switch_profiles:
         return None
     logger.info('Adding profile override middleware')
     middleware = ProfileOverrideMiddleware(
-        allowed_profiles=allowed_profiles,
+        allowed_profiles=switch_profiles,
         service=service,
         region=region,
         metadata=metadata,
         timeout=timeout,
-        endpoint=args.endpoint,
+        endpoint=endpoint,
     )
     mcp.add_middleware(middleware)
     return middleware

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -29,7 +29,7 @@ class TestParseArgs:
 
         assert args.endpoint == 'https://test.example.com'
         assert args.service is None
-        assert args.profile is None
+        assert args.profiles is None
         assert args.region is None
         assert args.read_only is False
         assert args.log_level == 'ERROR'
@@ -73,7 +73,7 @@ class TestParseArgs:
 
         assert args.endpoint == 'https://test.example.com'
         assert args.service == 'lambda'
-        assert args.profile == 'prod'
+        assert args.profiles == ['prod']
         assert args.region == 'eu-west-1'
         assert args.read_only is True
         assert args.log_level == 'WARNING'
@@ -96,7 +96,7 @@ class TestParseArgs:
         args = parse_args()
 
         assert args.endpoint == 'https://test.example.com'
-        assert args.profile == 'env-profile'
+        assert args.profiles == ['env-profile']
 
     @patch.dict('os.environ', {'AWS_PROFILE': 'env-profile'})
     @patch(
@@ -107,7 +107,7 @@ class TestParseArgs:
         args = parse_args()
 
         assert args.endpoint == 'https://test.example.com'
-        assert args.profile == 'cli-profile'
+        assert args.profiles == ['cli-profile']
 
     @patch('sys.argv', ['mcp-proxy-for-aws', 'https://test.example.com', '--retries', '0'])
     def test_parse_args_retries_minimum(self):

--- a/tests/unit/test_profile_switcher.py
+++ b/tests/unit/test_profile_switcher.py
@@ -14,6 +14,7 @@
 
 """Tests for the ProfileOverrideMiddleware."""
 
+import asyncio
 import httpx
 import pytest
 from fastmcp.server.middleware import MiddlewareContext
@@ -204,6 +205,46 @@ class TestPerCallProfileOverride:
 
         assert 'tool call failed' in result.content[0].text
         assert 'backend error' not in result.content[0].text
+
+
+class TestGetProfileClient:
+    """Tests for the _get_profile_client method."""
+
+    @pytest.mark.asyncio
+    async def test_lock_prevents_duplicate_client_creation(self, middleware):
+        """Concurrent calls for the same profile only create one client."""
+        call_count = 0
+        mock_client = AsyncMock()
+
+        original_aenter = mock_client.__aenter__
+
+        async def slow_aenter(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return await original_aenter(*args, **kwargs)
+
+        mock_client.__aenter__ = slow_aenter
+
+        mock_transport = Mock()
+
+        with patch(
+            'mcp_proxy_for_aws.middleware.profile_switcher.create_transport_with_sigv4',
+            return_value=mock_transport,
+        ), patch(
+            'mcp_proxy_for_aws.middleware.profile_switcher.Client',
+            return_value=mock_client,
+        ):
+            results = await asyncio.gather(
+                middleware._get_profile_client('dev-profile'),
+                middleware._get_profile_client('dev-profile'),
+                middleware._get_profile_client('dev-profile'),
+            )
+
+        # All calls return the same client
+        assert all(r is mock_client for r in results)
+        # Client was only created once despite 3 concurrent calls
+        assert call_count == 1
 
 
 class TestDisconnectProfileClients:

--- a/tests/unit/test_profile_switcher.py
+++ b/tests/unit/test_profile_switcher.py
@@ -17,6 +17,7 @@
 import asyncio
 import httpx
 import pytest
+from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import MiddlewareContext
 from mcp_proxy_for_aws.middleware.profile_switcher import ProfileOverrideMiddleware
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -51,8 +52,8 @@ class TestOnListTools:
     """Tests for the on_list_tools method."""
 
     @pytest.mark.asyncio
-    async def test_injects_profile_property_into_tool_schemas(self, middleware, mock_context):
-        """Every proxied tool gets a profile property in its schema."""
+    async def test_injects_proxy_profile_property_into_tool_schemas(self, middleware, mock_context):
+        """Every proxied tool gets a proxy_profile property in its schema."""
         tool = Mock()
         tool.name = 'some_tool'
         tool.parameters = {'type': 'object', 'properties': {'arg': {'type': 'string'}}}
@@ -62,7 +63,7 @@ class TestOnListTools:
 
         assert len(result) == 1
         assert result[0].name == 'some_tool'
-        profile_schema = result[0].parameters['properties']['profile']
+        profile_schema = result[0].parameters['properties']['proxy_profile']
         assert profile_schema['type'] == 'string'
         assert 'AWS CLI profile' in profile_schema['description']
         assert profile_schema['enum'] == sorted(ALLOWED_PROFILES)
@@ -101,15 +102,15 @@ class TestOnListTools:
         result = await middleware.on_list_tools(mock_context, call_next)
 
         assert 'properties' in result[0].parameters
-        assert 'profile' in result[0].parameters['properties']
+        assert 'proxy_profile' in result[0].parameters['properties']
 
 
 class TestOnCallTool:
     """Tests for the on_call_tool method."""
 
     @pytest.mark.asyncio
-    async def test_passes_through_calls_without_profile(self, middleware, mock_context):
-        """Tool calls without profile are forwarded unchanged."""
+    async def test_passes_through_calls_without_proxy_profile(self, middleware, mock_context):
+        """Tool calls without proxy_profile are forwarded unchanged."""
         mock_context.message = Mock()
         mock_context.message.name = 'some_tool'
         mock_context.message.arguments = {'arg': 'value'}
@@ -141,20 +142,20 @@ class TestPerCallProfileOverride:
 
     @pytest.mark.asyncio
     async def test_profile_override_disallowed(self, middleware, mock_context):
-        """Profile with a disallowed profile returns an error."""
+        """Disallowed profile raises ToolError."""
         mock_context.message = Mock()
         mock_context.message.name = 'some_tool'
-        mock_context.message.arguments = {'arg': 'value', 'profile': 'evil-profile'}
+        mock_context.message.arguments = {'arg': 'value', 'proxy_profile': 'evil-profile'}
         call_next = AsyncMock()
 
-        result = await middleware.on_call_tool(mock_context, call_next)
+        with pytest.raises(ToolError, match='not in the allowed list'):
+            await middleware.on_call_tool(mock_context, call_next)
 
-        assert 'not in the allowed list' in result.content[0].text
         call_next.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_profile_override_strips_profile_arg(self, middleware, mock_context):
-        """Profile is stripped before forwarding to the backend."""
+    async def test_profile_override_strips_proxy_profile_arg(self, middleware, mock_context):
+        """proxy_profile is stripped before forwarding to the backend."""
         mock_client = AsyncMock()
         mock_call_result = MagicMock()
         mock_call_result.content = 'result'
@@ -164,7 +165,7 @@ class TestPerCallProfileOverride:
 
         mock_context.message = Mock()
         mock_context.message.name = 'some_tool'
-        mock_context.message.arguments = {'arg': 'value', 'profile': 'dev-profile'}
+        mock_context.message.arguments = {'arg': 'value', 'proxy_profile': 'dev-profile'}
         call_next = AsyncMock()
 
         with patch.object(middleware, '_get_profile_client', return_value=mock_client):
@@ -175,36 +176,36 @@ class TestPerCallProfileOverride:
 
     @pytest.mark.asyncio
     async def test_profile_override_connection_failure(self, middleware, mock_context):
-        """Connection failure returns a sanitized error."""
+        """Connection failure raises ToolError with sanitized message."""
         mock_context.message = Mock()
         mock_context.message.name = 'some_tool'
-        mock_context.message.arguments = {'arg': 'value', 'profile': 'dev-profile'}
+        mock_context.message.arguments = {'arg': 'value', 'proxy_profile': 'dev-profile'}
         call_next = AsyncMock()
 
         with patch.object(
             middleware, '_get_profile_client', side_effect=Exception('connection refused')
         ):
-            result = await middleware.on_call_tool(mock_context, call_next)
+            with pytest.raises(ToolError, match='Failed to create connection') as exc_info:
+                await middleware.on_call_tool(mock_context, call_next)
 
-        assert 'failed to create connection' in result.content[0].text
-        assert 'connection refused' not in result.content[0].text
+        assert 'connection refused' not in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_profile_override_tool_call_failure(self, middleware, mock_context):
-        """Tool call failure returns a sanitized error."""
+        """Tool call failure raises ToolError with sanitized message."""
         mock_client = AsyncMock()
         mock_client.call_tool.side_effect = Exception('backend error')
 
         mock_context.message = Mock()
         mock_context.message.name = 'some_tool'
-        mock_context.message.arguments = {'arg': 'value', 'profile': 'dev-profile'}
+        mock_context.message.arguments = {'arg': 'value', 'proxy_profile': 'dev-profile'}
         call_next = AsyncMock()
 
         with patch.object(middleware, '_get_profile_client', return_value=mock_client):
-            result = await middleware.on_call_tool(mock_context, call_next)
+            with pytest.raises(ToolError, match='Tool call failed') as exc_info:
+                await middleware.on_call_tool(mock_context, call_next)
 
-        assert 'tool call failed' in result.content[0].text
-        assert 'backend error' not in result.content[0].text
+        assert 'backend error' not in str(exc_info.value)
 
 
 class TestGetProfileClient:

--- a/tests/unit/test_profile_switcher.py
+++ b/tests/unit/test_profile_switcher.py
@@ -52,7 +52,9 @@ class TestOnListTools:
     """Tests for the on_list_tools method."""
 
     @pytest.mark.asyncio
-    async def test_injects_proxy_profile_property_into_tool_schemas(self, middleware, mock_context):
+    async def test_injects_proxy_profile_property_into_tool_schemas(
+        self, middleware, mock_context
+    ):
         """Every proxied tool gets a proxy_profile property in its schema."""
         tool = Mock()
         tool.name = 'some_tool'
@@ -229,12 +231,15 @@ class TestGetProfileClient:
 
         mock_transport = Mock()
 
-        with patch(
-            'mcp_proxy_for_aws.middleware.profile_switcher.create_transport_with_sigv4',
-            return_value=mock_transport,
-        ), patch(
-            'mcp_proxy_for_aws.middleware.profile_switcher.Client',
-            return_value=mock_client,
+        with (
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.create_transport_with_sigv4',
+                return_value=mock_transport,
+            ),
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.Client',
+                return_value=mock_client,
+            ),
         ):
             results = await asyncio.gather(
                 middleware._get_profile_client('dev-profile'),

--- a/tests/unit/test_profile_switcher.py
+++ b/tests/unit/test_profile_switcher.py
@@ -1,0 +1,237 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ProfileOverrideMiddleware."""
+
+import httpx
+import pytest
+from fastmcp.server.middleware import MiddlewareContext
+from mcp_proxy_for_aws.middleware.profile_switcher import ProfileOverrideMiddleware
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+
+ALLOWED_PROFILES = [
+    'dev-profile',
+    'staging-profile',
+]
+
+
+@pytest.fixture
+def middleware():
+    """Create a ProfileOverrideMiddleware instance."""
+    return ProfileOverrideMiddleware(
+        allowed_profiles=ALLOWED_PROFILES,
+        service='lambda',
+        region='us-east-1',
+        metadata={'proxy': 'test'},
+        timeout=httpx.Timeout(30),
+        endpoint='https://test.us-east-1.api.aws/mcp',
+    )
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock MiddlewareContext."""
+    return Mock(spec=MiddlewareContext)
+
+
+class TestOnListTools:
+    """Tests for the on_list_tools method."""
+
+    @pytest.mark.asyncio
+    async def test_injects_profile_property_into_tool_schemas(self, middleware, mock_context):
+        """Every proxied tool gets a profile property in its schema."""
+        tool = Mock()
+        tool.name = 'some_tool'
+        tool.parameters = {'type': 'object', 'properties': {'arg': {'type': 'string'}}}
+        call_next = AsyncMock(return_value=[tool])
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        assert len(result) == 1
+        assert result[0].name == 'some_tool'
+        profile_schema = result[0].parameters['properties']['profile']
+        assert profile_schema['type'] == 'string'
+        assert 'AWS CLI profile' in profile_schema['description']
+        assert profile_schema['enum'] == sorted(ALLOWED_PROFILES)
+        call_next.assert_called_once_with(mock_context)
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_tool_list(self, middleware, mock_context):
+        """Empty tool list is returned as-is."""
+        call_next = AsyncMock(return_value=[])
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_tool_with_non_dict_parameters(self, middleware, mock_context):
+        """Tools whose parameters are not a dict are left unchanged."""
+        tool = Mock()
+        tool.name = 'odd_tool'
+        tool.parameters = None
+        call_next = AsyncMock(return_value=[tool])
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        assert len(result) == 1
+        assert result[0].parameters is None
+
+    @pytest.mark.asyncio
+    async def test_adds_properties_key_when_missing(self, middleware, mock_context):
+        """Profile is injected even when the schema has no properties key."""
+        tool = Mock()
+        tool.name = 'bare_tool'
+        tool.parameters = {'type': 'object'}
+        call_next = AsyncMock(return_value=[tool])
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        assert 'properties' in result[0].parameters
+        assert 'profile' in result[0].parameters['properties']
+
+
+class TestOnCallTool:
+    """Tests for the on_call_tool method."""
+
+    @pytest.mark.asyncio
+    async def test_passes_through_calls_without_profile(self, middleware, mock_context):
+        """Tool calls without profile are forwarded unchanged."""
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = {'arg': 'value'}
+        expected_result = Mock()
+        call_next = AsyncMock(return_value=expected_result)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result == expected_result
+        call_next.assert_called_once_with(mock_context)
+
+    @pytest.mark.asyncio
+    async def test_passes_through_calls_with_none_arguments(self, middleware, mock_context):
+        """Tool calls with None arguments are forwarded unchanged."""
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = None
+        expected_result = Mock()
+        call_next = AsyncMock(return_value=expected_result)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result == expected_result
+        call_next.assert_called_once_with(mock_context)
+
+
+class TestPerCallProfileOverride:
+    """Tests for the profile per-call override path."""
+
+    @pytest.mark.asyncio
+    async def test_profile_override_disallowed(self, middleware, mock_context):
+        """Profile with a disallowed profile returns an error."""
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = {'arg': 'value', 'profile': 'evil-profile'}
+        call_next = AsyncMock()
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert 'not in the allowed list' in result.content[0].text
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_profile_override_strips_profile_arg(self, middleware, mock_context):
+        """Profile is stripped before forwarding to the backend."""
+        mock_client = AsyncMock()
+        mock_call_result = MagicMock()
+        mock_call_result.content = 'result'
+        mock_call_result.structured_content = None
+        mock_call_result.meta = None
+        mock_client.call_tool.return_value = mock_call_result
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = {'arg': 'value', 'profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(middleware, '_get_profile_client', return_value=mock_client):
+            await middleware.on_call_tool(mock_context, call_next)
+
+        mock_client.call_tool.assert_called_once_with('some_tool', {'arg': 'value'})
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_profile_override_connection_failure(self, middleware, mock_context):
+        """Connection failure returns a sanitized error."""
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = {'arg': 'value', 'profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(
+            middleware, '_get_profile_client', side_effect=Exception('connection refused')
+        ):
+            result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert 'failed to create connection' in result.content[0].text
+        assert 'connection refused' not in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_profile_override_tool_call_failure(self, middleware, mock_context):
+        """Tool call failure returns a sanitized error."""
+        mock_client = AsyncMock()
+        mock_client.call_tool.side_effect = Exception('backend error')
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = {'arg': 'value', 'profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(middleware, '_get_profile_client', return_value=mock_client):
+            result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert 'tool call failed' in result.content[0].text
+        assert 'backend error' not in result.content[0].text
+
+
+class TestDisconnectProfileClients:
+    """Tests for the disconnect_profile_clients method."""
+
+    @pytest.mark.asyncio
+    async def test_disconnects_all_clients(self, middleware):
+        """All cached profile clients are closed and the cache is cleared."""
+        client_a = AsyncMock()
+        client_b = AsyncMock()
+        middleware._profile_clients = {'profile-a': client_a, 'profile-b': client_b}
+
+        await middleware.disconnect_profile_clients()
+
+        client_a.__aexit__.assert_called_once_with(None, None, None)
+        client_b.__aexit__.assert_called_once_with(None, None, None)
+        assert middleware._profile_clients == {}
+
+    @pytest.mark.asyncio
+    async def test_continues_on_client_error(self, middleware):
+        """A failing client does not prevent other clients from disconnecting."""
+        client_good = AsyncMock()
+        client_bad = AsyncMock()
+        client_bad.__aexit__.side_effect = Exception('disconnect failed')
+        middleware._profile_clients = {'bad': client_bad, 'good': client_good}
+
+        await middleware.disconnect_profile_clients()
+
+        client_bad.__aexit__.assert_called_once_with(None, None, None)
+        client_good.__aexit__.assert_called_once_with(None, None, None)
+        assert middleware._profile_clients == {}

--- a/tests/unit/test_profile_switcher.py
+++ b/tests/unit/test_profile_switcher.py
@@ -1,0 +1,530 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ProfileOverrideMiddleware."""
+
+import asyncio
+import httpx
+import pytest
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import MiddlewareContext
+from mcp_proxy_for_aws.middleware.profile_switcher import ProfileOverrideMiddleware
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+
+ALLOWED_PROFILES = [
+    'default-profile',
+    'dev-profile',
+    'staging-profile',
+]
+
+
+@pytest.fixture
+def middleware():
+    """Create a ProfileOverrideMiddleware instance."""
+    return ProfileOverrideMiddleware(
+        allowed_profiles=ALLOWED_PROFILES,
+        default_profile='default-profile',
+        service='lambda',
+        region='us-east-1',
+        metadata={'proxy': 'test'},
+        timeout=httpx.Timeout(30),
+        endpoint='https://test.us-east-1.api.aws/mcp',
+    )
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock MiddlewareContext."""
+    return Mock(spec=MiddlewareContext)
+
+
+class TestOnListTools:
+    """Tests for the on_list_tools method."""
+
+    @pytest.mark.asyncio
+    async def test_injects_aws_profile_property_into_tool_schemas(self, middleware, mock_context):
+        """Auth-requiring tools get a aws_profile property in their schema."""
+        tool = Mock()
+        tool.name = 'aws___call_aws'
+        tool.parameters = {'type': 'object', 'properties': {'arg': {'type': 'string'}}}
+        call_next = AsyncMock(return_value=[tool])
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        assert len(result) == 1
+        assert result[0].name == 'aws___call_aws'
+        profile_schema = result[0].parameters['properties']['aws_profile']
+        assert profile_schema['type'] == 'string'
+        assert 'AWS CLI profile' in profile_schema['description']
+        assert profile_schema['enum'] == sorted(ALLOWED_PROFILES)
+        call_next.assert_called_once_with(mock_context)
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_tool_list(self, middleware, mock_context):
+        """Empty tool list is returned as-is."""
+        call_next = AsyncMock(return_value=[])
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_tool_with_non_dict_parameters(self, middleware, mock_context):
+        """Tools whose parameters are not a dict are left unchanged."""
+        tool = Mock()
+        tool.name = 'aws___call_aws'
+        tool.parameters = None
+        call_next = AsyncMock(return_value=[tool])
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        assert len(result) == 1
+        assert result[0].parameters is None
+
+    @pytest.mark.asyncio
+    async def test_adds_properties_key_when_missing(self, middleware, mock_context):
+        """Profile is injected even when the schema has no properties key."""
+        tool = Mock()
+        tool.name = 'aws___run_script'
+        tool.parameters = {'type': 'object'}
+        call_next = AsyncMock(return_value=[tool])
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        assert 'properties' in result[0].parameters
+        assert 'aws_profile' in result[0].parameters['properties']
+
+    @pytest.mark.asyncio
+    async def test_skips_non_auth_requiring_tools(self, middleware, mock_context):
+        """Non-auth tools do not get aws_profile injected."""
+        auth_tool = Mock()
+        auth_tool.name = 'aws___call_aws'
+        auth_tool.parameters = {'type': 'object', 'properties': {'arg': {'type': 'string'}}}
+
+        non_auth_tool = Mock()
+        non_auth_tool.name = 'search_documentation'
+        non_auth_tool.parameters = {'type': 'object', 'properties': {'query': {'type': 'string'}}}
+
+        call_next = AsyncMock(return_value=[auth_tool, non_auth_tool])
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        assert 'aws_profile' in result[0].parameters['properties']
+        assert 'aws_profile' not in result[1].parameters['properties']
+
+
+class TestOnCallTool:
+    """Tests for the on_call_tool method."""
+
+    @pytest.mark.asyncio
+    async def test_passes_through_calls_without_aws_profile(self, middleware, mock_context):
+        """Tool calls without aws_profile are forwarded unchanged."""
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = {'arg': 'value'}
+        expected_result = Mock()
+        call_next = AsyncMock(return_value=expected_result)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result == expected_result
+        call_next.assert_called_once_with(mock_context)
+
+    @pytest.mark.asyncio
+    async def test_passes_through_calls_with_none_arguments(self, middleware, mock_context):
+        """Tool calls with None arguments are forwarded unchanged."""
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = None
+        expected_result = Mock()
+        call_next = AsyncMock(return_value=expected_result)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result == expected_result
+        call_next.assert_called_once_with(mock_context)
+
+
+class TestPerCallProfileOverride:
+    """Tests for the profile per-call override path."""
+
+    @pytest.mark.asyncio
+    async def test_profile_override_disallowed(self, middleware, mock_context):
+        """Disallowed profile raises ToolError."""
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'evil-profile'}
+        call_next = AsyncMock()
+
+        with pytest.raises(ToolError, match='not in the allowed list'):
+            await middleware.on_call_tool(mock_context, call_next)
+
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_profile_override_strips_aws_profile_arg(self, middleware, mock_context):
+        """aws_profile is stripped before forwarding to the backend."""
+        mock_client = AsyncMock()
+        mock_call_result = MagicMock()
+        mock_call_result.content = 'result'
+        mock_call_result.structured_content = None
+        mock_call_result.meta = None
+        mock_call_result.is_error = False
+        mock_client.call_tool.return_value = mock_call_result
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(middleware, '_get_profile_client', return_value=mock_client):
+            await middleware.on_call_tool(mock_context, call_next)
+
+        mock_client.call_tool.assert_called_once_with(
+            'some_tool', {'arg': 'value'}, raise_on_error=False
+        )
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_default_profile_routes_through_call_next(self, middleware, mock_context):
+        """When aws_profile matches the default, route through normal path."""
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'default-profile'}
+        expected_result = Mock()
+        call_next = AsyncMock(return_value=expected_result)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result == expected_result
+        call_next.assert_called_once_with(mock_context)
+        # aws_profile should be stripped from arguments
+        assert 'aws_profile' not in mock_context.message.arguments
+
+    @pytest.mark.asyncio
+    async def test_profile_override_propagates_is_error(self, middleware, mock_context):
+        """Backend isError=True is propagated as a ToolError."""
+        mock_client = AsyncMock()
+        mock_call_result = MagicMock()
+        mock_content_block = MagicMock()
+        mock_content_block.text = 'backend error message'
+        mock_call_result.content = [mock_content_block]
+        mock_call_result.structured_content = None
+        mock_call_result.meta = None
+        mock_call_result.is_error = True
+        mock_client.call_tool.return_value = mock_call_result
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(middleware, '_get_profile_client', return_value=mock_client):
+            with pytest.raises(ToolError, match='backend error message'):
+                await middleware.on_call_tool(mock_context, call_next)
+
+    @pytest.mark.asyncio
+    async def test_profile_override_connection_failure(self, middleware, mock_context):
+        """Connection failure raises ToolError with sanitized message."""
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(
+            middleware, '_get_profile_client', side_effect=Exception('connection refused')
+        ):
+            with pytest.raises(ToolError, match='Failed to create connection') as exc_info:
+                await middleware.on_call_tool(mock_context, call_next)
+
+        assert 'connection refused' not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_profile_override_tool_call_failure(self, middleware, mock_context):
+        """Tool call failure raises ToolError with sanitized message."""
+        mock_client = AsyncMock()
+        mock_client.call_tool.side_effect = Exception('backend error')
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'some_tool'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(middleware, '_get_profile_client', return_value=mock_client):
+            with pytest.raises(ToolError, match='Tool call failed') as exc_info:
+                await middleware.on_call_tool(mock_context, call_next)
+
+        assert 'backend error' not in str(exc_info.value)
+
+
+class TestGetProfileClient:
+    """Tests for the _get_profile_client method."""
+
+    @pytest.mark.asyncio
+    async def test_lock_prevents_duplicate_client_creation(self, middleware):
+        """Concurrent calls for the same profile only create one client."""
+        call_count = 0
+        mock_client = AsyncMock()
+
+        original_aenter = mock_client.__aenter__
+
+        async def slow_aenter(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return await original_aenter(*args, **kwargs)
+
+        mock_client.__aenter__ = slow_aenter
+
+        mock_transport = Mock()
+
+        with (
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.create_transport_with_sigv4',
+                return_value=mock_transport,
+            ),
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.Client',
+                return_value=mock_client,
+            ),
+        ):
+            results = await asyncio.gather(
+                middleware._get_profile_client('dev-profile'),
+                middleware._get_profile_client('dev-profile'),
+                middleware._get_profile_client('dev-profile'),
+            )
+
+        # All calls return the same client
+        assert all(r is mock_client for r in results)
+        # Client was only created once despite 3 concurrent calls
+        assert call_count == 1
+
+
+class TestDisconnectProfileClients:
+    """Tests for the disconnect_profile_clients method."""
+
+    @pytest.mark.asyncio
+    async def test_disconnects_all_clients(self, middleware):
+        """All cached profile clients are closed and the cache is cleared."""
+        client_a = AsyncMock()
+        client_b = AsyncMock()
+        middleware._profile_clients = {'profile-a': client_a, 'profile-b': client_b}
+
+        await middleware.disconnect_profile_clients()
+
+        client_a.__aexit__.assert_called_once_with(None, None, None)
+        client_b.__aexit__.assert_called_once_with(None, None, None)
+        assert middleware._profile_clients == {}
+
+    @pytest.mark.asyncio
+    async def test_continues_on_client_error(self, middleware):
+        """A failing client does not prevent other clients from disconnecting."""
+        client_good = AsyncMock()
+        client_bad = AsyncMock()
+        client_bad.__aexit__.side_effect = Exception('disconnect failed')
+        middleware._profile_clients = {'bad': client_bad, 'good': client_good}
+
+        await middleware.disconnect_profile_clients()
+
+        client_bad.__aexit__.assert_called_once_with(None, None, None)
+        client_good.__aexit__.assert_called_once_with(None, None, None)
+        assert middleware._profile_clients == {}
+
+
+class TestFix1OnlyAuthToolsGetInjection:
+    """Fix #1: aws_profile only injected on auth-requiring tools."""
+
+    @pytest.mark.asyncio
+    async def test_all_auth_tools_get_injection(self, middleware, mock_context):
+        """All four auth-requiring tools get aws_profile."""
+        tools = []
+        for name in [
+            'aws___call_aws',
+            'aws___run_script',
+            'aws___get_presigned_url',
+            'aws___get_tasks',
+        ]:
+            tool = Mock()
+            tool.name = name
+            tool.parameters = {'type': 'object', 'properties': {}}
+            tools.append(tool)
+        call_next = AsyncMock(return_value=tools)
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        for tool in result:
+            assert 'aws_profile' in tool.parameters['properties'], (
+                f'{tool.name} should have aws_profile'
+            )
+
+    @pytest.mark.asyncio
+    async def test_non_auth_tools_never_get_injection(self, middleware, mock_context):
+        """Non-auth tools like search_documentation, list_regions, etc. are untouched."""
+        tools = []
+        for name in [
+            'search_documentation',
+            'read_documentation',
+            'list_regions',
+            'recommend',
+            'retrieve_skill',
+            'suggest_aws_commands',
+            'get_regional_availability',
+        ]:
+            tool = Mock()
+            tool.name = name
+            tool.parameters = {'type': 'object', 'properties': {'q': {'type': 'string'}}}
+            tools.append(tool)
+        call_next = AsyncMock(return_value=tools)
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        for tool in result:
+            assert 'aws_profile' not in tool.parameters['properties'], (
+                f'{tool.name} should NOT have aws_profile'
+            )
+
+
+class TestFix3DefaultProfileInEnum:
+    """Fix #3: Default profile included in enum and routes through call_next."""
+
+    @pytest.mark.asyncio
+    async def test_default_profile_appears_in_enum(self, middleware, mock_context):
+        """The default profile is included in the schema enum."""
+        tool = Mock()
+        tool.name = 'aws___call_aws'
+        tool.parameters = {'type': 'object', 'properties': {}}
+        call_next = AsyncMock(return_value=[tool])
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        enum_values = result[0].parameters['properties']['aws_profile']['enum']
+        assert 'default-profile' in enum_values
+
+    @pytest.mark.asyncio
+    async def test_default_profile_does_not_create_separate_client(self, middleware, mock_context):
+        """Passing the default profile does not create a dedicated client."""
+        mock_context.message = Mock()
+        mock_context.message.name = 'aws___call_aws'
+        mock_context.message.arguments = {
+            'cli_command': 'aws sts get-caller-identity',
+            'aws_profile': 'default-profile',
+        }
+        expected_result = Mock()
+        call_next = AsyncMock(return_value=expected_result)
+
+        await middleware.on_call_tool(mock_context, call_next)
+
+        # No profile client should have been created
+        assert 'default-profile' not in middleware._profile_clients
+
+    @pytest.mark.asyncio
+    async def test_default_profile_strips_param_before_call_next(self, middleware, mock_context):
+        """aws_profile is stripped even when routing through default path."""
+        mock_context.message = Mock()
+        mock_context.message.arguments = {
+            'cli_command': 'aws s3 ls',
+            'aws_profile': 'default-profile',
+        }
+        mock_context.message.name = 'aws___call_aws'
+        call_next = AsyncMock(return_value=Mock())
+
+        await middleware.on_call_tool(mock_context, call_next)
+
+        # The arguments passed to call_next should not contain aws_profile
+        assert 'aws_profile' not in mock_context.message.arguments
+        assert 'cli_command' in mock_context.message.arguments
+
+
+class TestFix4RetryExceptionChaining:
+    """Fix #4: Exception chain preserved so RetryMiddleware can retry."""
+
+    @pytest.mark.asyncio
+    async def test_tool_call_failure_preserves_cause(self, middleware, mock_context):
+        """ToolError from tool call failure has __cause__ set to original exception."""
+        mock_client = AsyncMock()
+        original_error = ConnectionError('connection reset')
+        mock_client.call_tool.side_effect = original_error
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'aws___call_aws'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(middleware, '_get_profile_client', return_value=mock_client):
+            with pytest.raises(ToolError) as exc_info:
+                await middleware.on_call_tool(mock_context, call_next)
+
+        assert exc_info.value.__cause__ is original_error
+
+    @pytest.mark.asyncio
+    async def test_connection_failure_preserves_cause(self, middleware, mock_context):
+        """ToolError from connection failure has __cause__ set to original exception."""
+        original_error = TimeoutError('connect timed out')
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'aws___call_aws'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(middleware, '_get_profile_client', side_effect=original_error):
+            with pytest.raises(ToolError) as exc_info:
+                await middleware.on_call_tool(mock_context, call_next)
+
+        assert exc_info.value.__cause__ is original_error
+
+
+class TestFix5IsErrorPropagation:
+    """Fix #5: Backend isError=True is propagated as ToolError."""
+
+    @pytest.mark.asyncio
+    async def test_is_error_true_raises_tool_error(self, middleware, mock_context):
+        """When backend returns isError=True, a ToolError is raised."""
+        mock_client = AsyncMock()
+        mock_call_result = MagicMock()
+        mock_content_block = MagicMock()
+        mock_content_block.text = 'Access denied for this operation'
+        mock_call_result.content = [mock_content_block]
+        mock_call_result.is_error = True
+        mock_client.call_tool.return_value = mock_call_result
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'aws___call_aws'
+        mock_context.message.arguments = {'cli_command': 'aws s3 ls', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(middleware, '_get_profile_client', return_value=mock_client):
+            with pytest.raises(ToolError, match='Access denied for this operation'):
+                await middleware.on_call_tool(mock_context, call_next)
+
+    @pytest.mark.asyncio
+    async def test_is_error_false_returns_result(self, middleware, mock_context):
+        """When backend returns isError=False, a normal ToolResult is returned."""
+        mock_client = AsyncMock()
+        mock_call_result = MagicMock()
+        mock_call_result.content = 'success'
+        mock_call_result.structured_content = None
+        mock_call_result.meta = None
+        mock_call_result.is_error = False
+        mock_client.call_tool.return_value = mock_call_result
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'aws___call_aws'
+        mock_context.message.arguments = {'cli_command': 'aws s3 ls', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(middleware, '_get_profile_client', return_value=mock_client):
+            result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result.content is not None

--- a/tests/unit/test_profile_switcher.py
+++ b/tests/unit/test_profile_switcher.py
@@ -41,6 +41,8 @@ def middleware():
         metadata={'proxy': 'test'},
         timeout=httpx.Timeout(30),
         endpoint='https://test.us-east-1.api.aws/mcp',
+        disable_telemetry=False,
+        skip_auth=False,
     )
 
 
@@ -164,7 +166,7 @@ class TestPerCallProfileOverride:
     async def test_profile_override_disallowed(self, middleware, mock_context):
         """Disallowed profile raises ToolError."""
         mock_context.message = Mock()
-        mock_context.message.name = 'some_tool'
+        mock_context.message.name = 'aws___call_aws'
         mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'evil-profile'}
         call_next = AsyncMock()
 
@@ -185,7 +187,7 @@ class TestPerCallProfileOverride:
         mock_client.call_tool.return_value = mock_call_result
 
         mock_context.message = Mock()
-        mock_context.message.name = 'some_tool'
+        mock_context.message.name = 'aws___call_aws'
         mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
         call_next = AsyncMock()
 
@@ -193,7 +195,7 @@ class TestPerCallProfileOverride:
             await middleware.on_call_tool(mock_context, call_next)
 
         mock_client.call_tool.assert_called_once_with(
-            'some_tool', {'arg': 'value'}, raise_on_error=False
+            'aws___call_aws', {'arg': 'value'}, raise_on_error=False
         )
         call_next.assert_not_called()
 
@@ -227,7 +229,7 @@ class TestPerCallProfileOverride:
         mock_client.call_tool.return_value = mock_call_result
 
         mock_context.message = Mock()
-        mock_context.message.name = 'some_tool'
+        mock_context.message.name = 'aws___call_aws'
         mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
         call_next = AsyncMock()
 
@@ -239,7 +241,7 @@ class TestPerCallProfileOverride:
     async def test_profile_override_connection_failure(self, middleware, mock_context):
         """Connection failure raises ToolError with sanitized message."""
         mock_context.message = Mock()
-        mock_context.message.name = 'some_tool'
+        mock_context.message.name = 'aws___call_aws'
         mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
         call_next = AsyncMock()
 
@@ -258,7 +260,7 @@ class TestPerCallProfileOverride:
         mock_client.call_tool.side_effect = Exception('backend error')
 
         mock_context.message = Mock()
-        mock_context.message.name = 'some_tool'
+        mock_context.message.name = 'aws___call_aws'
         mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
         call_next = AsyncMock()
 
@@ -354,6 +356,7 @@ class TestFix1OnlyAuthToolsGetInjection:
             'aws___call_aws',
             'aws___run_script',
             'aws___get_presigned_url',
+            'aws___get_tasks',
             'aws___suggest_aws_commands',
         ]:
             tool = Mock()
@@ -380,7 +383,6 @@ class TestFix1OnlyAuthToolsGetInjection:
             'recommend',
             'retrieve_skill',
             'get_regional_availability',
-            'aws___get_tasks',
         ]:
             tool = Mock()
             tool.name = name
@@ -723,3 +725,87 @@ class TestRetryMiddlewareIntegration:
         # No __cause__ set (e.g., disallowed profile validation error)
 
         assert retry_mw._should_retry(tool_error) is False
+
+
+class TestNonAuthToolIgnoresAwsProfile:
+    """Verify aws_profile on non-auth tools is stripped and routed normally."""
+
+    @pytest.mark.asyncio
+    async def test_non_auth_tool_with_aws_profile_strips_and_passes_through(
+        self, middleware, mock_context
+    ):
+        """Non-auth tool with aws_profile has it stripped and routes through call_next."""
+        mock_context.message = Mock()
+        mock_context.message.name = 'search_documentation'
+        mock_context.message.arguments = {
+            'query': 'lambda cold starts',
+            'aws_profile': 'dev-profile',
+        }
+        expected_result = Mock()
+        call_next = AsyncMock(return_value=expected_result)
+
+        result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result == expected_result
+        call_next.assert_called_once_with(mock_context)
+        # aws_profile should be stripped
+        assert 'aws_profile' not in mock_context.message.arguments
+        # Original args preserved
+        assert mock_context.message.arguments['query'] == 'lambda cold starts'
+
+    @pytest.mark.asyncio
+    async def test_non_auth_tool_does_not_create_profile_client(self, middleware, mock_context):
+        """Non-auth tool with aws_profile does not create a dedicated client."""
+        mock_context.message = Mock()
+        mock_context.message.name = 'list_regions'
+        mock_context.message.arguments = {'aws_profile': 'staging-profile'}
+        call_next = AsyncMock(return_value=Mock())
+
+        await middleware.on_call_tool(mock_context, call_next)
+
+        assert 'staging-profile' not in middleware._profile_clients
+
+
+class TestProfileClientTransportParams:
+    """Verify all constructor params are forwarded to create_transport_with_sigv4."""
+
+    @pytest.mark.asyncio
+    async def test_all_params_forwarded_to_transport_factory(self, mock_context):
+        """_get_profile_client passes all config params to create_transport_with_sigv4."""
+        mw = ProfileOverrideMiddleware(
+            allowed_profiles=['default-profile', 'dev-profile'],
+            default_profile='default-profile',
+            service='bedrock-agentcore',
+            region='eu-west-1',
+            metadata={'AWS_REGION': 'eu-west-1', 'custom': 'val'},
+            timeout=httpx.Timeout(60),
+            endpoint='https://bedrock-agentcore.eu-west-1.api.aws/mcp',
+            disable_telemetry=True,
+            skip_auth=True,
+        )
+
+        mock_transport = Mock()
+        mock_client = AsyncMock()
+
+        with (
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.create_transport_with_sigv4',
+                return_value=mock_transport,
+            ) as mock_create,
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.Client',
+                return_value=mock_client,
+            ),
+        ):
+            await mw._get_profile_client('dev-profile')
+
+        mock_create.assert_called_once_with(
+            'https://bedrock-agentcore.eu-west-1.api.aws/mcp',
+            'bedrock-agentcore',
+            'eu-west-1',
+            {'AWS_REGION': 'eu-west-1', 'custom': 'val'},
+            httpx.Timeout(60),
+            'dev-profile',
+            True,
+            True,
+        )

--- a/tests/unit/test_profile_switcher.py
+++ b/tests/unit/test_profile_switcher.py
@@ -354,7 +354,7 @@ class TestFix1OnlyAuthToolsGetInjection:
             'aws___call_aws',
             'aws___run_script',
             'aws___get_presigned_url',
-            'aws___get_tasks',
+            'aws___suggest_aws_commands',
         ]:
             tool = Mock()
             tool.name = name
@@ -379,8 +379,8 @@ class TestFix1OnlyAuthToolsGetInjection:
             'list_regions',
             'recommend',
             'retrieve_skill',
-            'suggest_aws_commands',
             'get_regional_availability',
+            'aws___get_tasks',
         ]:
             tool = Mock()
             tool.name = name
@@ -528,3 +528,198 @@ class TestFix5IsErrorPropagation:
             result = await middleware.on_call_tool(mock_context, call_next)
 
         assert result.content is not None
+
+
+class TestRaiseOnErrorFalseEnforced:
+    """Verify raise_on_error=False is critical for error extraction logic."""
+
+    @pytest.mark.asyncio
+    async def test_raise_on_error_false_allows_is_error_extraction(self, middleware, mock_context):
+        """If raise_on_error were True, backend errors would bypass our extraction logic.
+
+        This test confirms the middleware correctly passes raise_on_error=False
+        and handles the is_error field from the result object.
+        """
+        mock_client = AsyncMock()
+        mock_call_result = MagicMock()
+        mock_content_block = MagicMock()
+        mock_content_block.text = 'ThrottlingException: Rate exceeded'
+        mock_call_result.content = [mock_content_block]
+        mock_call_result.is_error = True
+        mock_client.call_tool.return_value = mock_call_result
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'aws___call_aws'
+        mock_context.message.arguments = {'cli_command': 'aws s3 ls', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(middleware, '_get_profile_client', return_value=mock_client):
+            with pytest.raises(ToolError, match='ThrottlingException'):
+                await middleware.on_call_tool(mock_context, call_next)
+
+        # Confirm raise_on_error=False was passed
+        mock_client.call_tool.assert_called_once_with(
+            'aws___call_aws', {'cli_command': 'aws s3 ls'}, raise_on_error=False
+        )
+
+
+class TestStructuredContentAndMetaPassthrough:
+    """Verify structured_content and meta are propagated on success."""
+
+    @pytest.mark.asyncio
+    async def test_non_none_structured_content_and_meta_propagated(self, middleware, mock_context):
+        """Non-None structured_content and meta values are passed through to ToolResult."""
+        mock_client = AsyncMock()
+        mock_call_result = MagicMock()
+        mock_call_result.content = [MagicMock(text='ok')]
+        mock_call_result.structured_content = {'key': 'value', 'nested': [1, 2, 3]}
+        mock_call_result.meta = {'request_id': 'abc-123', 'latency_ms': 42}
+        mock_call_result.is_error = False
+        mock_client.call_tool.return_value = mock_call_result
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'aws___call_aws'
+        mock_context.message.arguments = {'cli_command': 'aws s3 ls', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with patch.object(middleware, '_get_profile_client', return_value=mock_client):
+            result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result.structured_content == {'key': 'value', 'nested': [1, 2, 3]}
+        assert result.meta == {'request_id': 'abc-123', 'latency_ms': 42}
+
+
+class TestAwsProfileAlreadyInSchema:
+    """Verify warning path when tool already defines aws_profile."""
+
+    @pytest.mark.asyncio
+    async def test_existing_aws_profile_is_overwritten_with_warning(
+        self, middleware, mock_context, caplog
+    ):
+        """Tool with pre-existing aws_profile gets it overwritten and a warning is logged."""
+        tool = Mock()
+        tool.name = 'aws___call_aws'
+        tool.parameters = {
+            'type': 'object',
+            'properties': {
+                'cli_command': {'type': 'string'},
+                'aws_profile': {
+                    'type': 'string',
+                    'description': 'Original backend definition',
+                    'enum': ['old-profile'],
+                },
+            },
+        }
+        call_next = AsyncMock(return_value=[tool])
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = await middleware.on_list_tools(mock_context, call_next)
+
+        # The middleware's version should overwrite the backend's
+        profile_schema = result[0].parameters['properties']['aws_profile']
+        assert profile_schema['enum'] == sorted(ALLOWED_PROFILES)
+        assert 'shadowing the backend definition' in caplog.text
+
+
+class TestLockWithDeterministicSynchronization:
+    """Deterministic lock test using asyncio.Event instead of sleep."""
+
+    @pytest.mark.asyncio
+    async def test_lock_prevents_duplicate_creation_deterministic(self, middleware):
+        """Concurrent calls for the same profile only create one client (event-based)."""
+        creation_count = 0
+        gate = asyncio.Event()
+        mock_client = AsyncMock()
+
+        async def slow_aenter(*args, **kwargs):
+            nonlocal creation_count
+            creation_count += 1
+            # Wait for the gate — simulates slow connection setup
+            await gate.wait()
+            return mock_client
+
+        mock_client.__aenter__ = slow_aenter
+
+        mock_transport = Mock()
+
+        with (
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.create_transport_with_sigv4',
+                return_value=mock_transport,
+            ),
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.Client',
+                return_value=mock_client,
+            ),
+        ):
+            # Start 3 concurrent requests for the same profile
+            tasks = [
+                asyncio.create_task(middleware._get_profile_client('staging-profile'))
+                for _ in range(3)
+            ]
+            # Let the event loop schedule all tasks
+            await asyncio.sleep(0)
+            # Release the gate
+            gate.set()
+            results = await asyncio.gather(*tasks)
+
+        assert all(r is mock_client for r in results)
+        assert creation_count == 1
+
+
+class TestRetryMiddlewareIntegration:
+    """Integration test: ProfileOverrideMiddleware + RetryMiddleware chained together."""
+
+    @pytest.mark.asyncio
+    async def test_retry_middleware_recognizes_connection_error_cause(self):
+        """RetryMiddleware._should_retry returns True for ToolError from ConnectionError."""
+        from fastmcp.server.middleware.error_handling import RetryMiddleware
+
+        retry_mw = RetryMiddleware(max_retries=2)
+
+        # Simulate what ProfileOverrideMiddleware does: raise ToolError(...) from ConnectionError
+        original = ConnectionError('connection reset by peer')
+        tool_error = ToolError("Tool call failed using profile 'dev'.")
+        tool_error.__cause__ = original
+
+        assert retry_mw._should_retry(tool_error) is True
+
+    @pytest.mark.asyncio
+    async def test_retry_middleware_recognizes_timeout_error_cause(self):
+        """RetryMiddleware._should_retry returns True for ToolError from TimeoutError."""
+        from fastmcp.server.middleware.error_handling import RetryMiddleware
+
+        retry_mw = RetryMiddleware(max_retries=2)
+
+        original = TimeoutError('connect timed out')
+        tool_error = ToolError("Failed to create connection for profile 'dev'.")
+        tool_error.__cause__ = original
+
+        assert retry_mw._should_retry(tool_error) is True
+
+    @pytest.mark.asyncio
+    async def test_retry_middleware_does_not_retry_non_transient_cause(self):
+        """RetryMiddleware._should_retry returns False for ToolError from ValueError."""
+        from fastmcp.server.middleware.error_handling import RetryMiddleware
+
+        retry_mw = RetryMiddleware(max_retries=2)
+
+        original = ValueError('invalid profile name')
+        tool_error = ToolError('Profile not in allowed list.')
+        tool_error.__cause__ = original
+
+        assert retry_mw._should_retry(tool_error) is False
+
+    @pytest.mark.asyncio
+    async def test_retry_middleware_does_not_retry_tool_error_without_cause(self):
+        """RetryMiddleware._should_retry returns False for ToolError with no __cause__."""
+        from fastmcp.server.middleware.error_handling import RetryMiddleware
+
+        retry_mw = RetryMiddleware(max_retries=2)
+
+        tool_error = ToolError("Profile 'evil' is not in the allowed list.")
+        # No __cause__ set (e.g., disallowed profile validation error)
+
+        assert retry_mw._should_retry(tool_error) is False

--- a/tests/unit/test_profile_switcher.py
+++ b/tests/unit/test_profile_switcher.py
@@ -52,10 +52,8 @@ class TestOnListTools:
     """Tests for the on_list_tools method."""
 
     @pytest.mark.asyncio
-    async def test_injects_proxy_profile_property_into_tool_schemas(
-        self, middleware, mock_context
-    ):
-        """Every proxied tool gets a proxy_profile property in its schema."""
+    async def test_injects_aws_profile_property_into_tool_schemas(self, middleware, mock_context):
+        """Every proxied tool gets an aws_profile property in its schema."""
         tool = Mock()
         tool.name = 'some_tool'
         tool.parameters = {'type': 'object', 'properties': {'arg': {'type': 'string'}}}
@@ -65,7 +63,7 @@ class TestOnListTools:
 
         assert len(result) == 1
         assert result[0].name == 'some_tool'
-        profile_schema = result[0].parameters['properties']['proxy_profile']
+        profile_schema = result[0].parameters['properties']['aws_profile']
         assert profile_schema['type'] == 'string'
         assert 'AWS CLI profile' in profile_schema['description']
         assert profile_schema['enum'] == sorted(ALLOWED_PROFILES)
@@ -104,15 +102,15 @@ class TestOnListTools:
         result = await middleware.on_list_tools(mock_context, call_next)
 
         assert 'properties' in result[0].parameters
-        assert 'proxy_profile' in result[0].parameters['properties']
+        assert 'aws_profile' in result[0].parameters['properties']
 
 
 class TestOnCallTool:
     """Tests for the on_call_tool method."""
 
     @pytest.mark.asyncio
-    async def test_passes_through_calls_without_proxy_profile(self, middleware, mock_context):
-        """Tool calls without proxy_profile are forwarded unchanged."""
+    async def test_passes_through_calls_without_aws_profile(self, middleware, mock_context):
+        """Tool calls without aws_profile are forwarded unchanged."""
         mock_context.message = Mock()
         mock_context.message.name = 'some_tool'
         mock_context.message.arguments = {'arg': 'value'}
@@ -147,7 +145,7 @@ class TestPerCallProfileOverride:
         """Disallowed profile raises ToolError."""
         mock_context.message = Mock()
         mock_context.message.name = 'some_tool'
-        mock_context.message.arguments = {'arg': 'value', 'proxy_profile': 'evil-profile'}
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'evil-profile'}
         call_next = AsyncMock()
 
         with pytest.raises(ToolError, match='not in the allowed list'):
@@ -156,8 +154,8 @@ class TestPerCallProfileOverride:
         call_next.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_profile_override_strips_proxy_profile_arg(self, middleware, mock_context):
-        """proxy_profile is stripped before forwarding to the backend."""
+    async def test_profile_override_strips_aws_profile_arg(self, middleware, mock_context):
+        """aws_profile is stripped before forwarding to the backend."""
         mock_client = AsyncMock()
         mock_call_result = MagicMock()
         mock_call_result.content = 'result'
@@ -167,7 +165,7 @@ class TestPerCallProfileOverride:
 
         mock_context.message = Mock()
         mock_context.message.name = 'some_tool'
-        mock_context.message.arguments = {'arg': 'value', 'proxy_profile': 'dev-profile'}
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
         call_next = AsyncMock()
 
         with patch.object(middleware, '_get_profile_client', return_value=mock_client):
@@ -181,7 +179,7 @@ class TestPerCallProfileOverride:
         """Connection failure raises ToolError with sanitized message."""
         mock_context.message = Mock()
         mock_context.message.name = 'some_tool'
-        mock_context.message.arguments = {'arg': 'value', 'proxy_profile': 'dev-profile'}
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
         call_next = AsyncMock()
 
         with patch.object(
@@ -200,7 +198,7 @@ class TestPerCallProfileOverride:
 
         mock_context.message = Mock()
         mock_context.message.name = 'some_tool'
-        mock_context.message.arguments = {'arg': 'value', 'proxy_profile': 'dev-profile'}
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
         call_next = AsyncMock()
 
         with patch.object(middleware, '_get_profile_client', return_value=mock_client):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -14,8 +14,13 @@
 
 """Tests for the mcp-proxy-for-aws Server."""
 
+import httpx
+import os
+import pytest
 from fastmcp.client.transports import ClientTransport
+from mcp_proxy_for_aws.middleware.profile_switcher import ProfileOverrideMiddleware
 from mcp_proxy_for_aws.server import (
+    add_profile_override_middleware,
     add_retry_middleware,
     add_tool_filtering_middleware,
     main,
@@ -53,7 +58,7 @@ class TestServer:
         mock_args.endpoint = 'https://test.example.com'
         mock_args.service = 'test-service'
         mock_args.region = 'us-east-1'
-        mock_args.profile = None
+        mock_args.profiles = None
         mock_args.read_only = True
         mock_args.retries = 1
         mock_args.metadata = None
@@ -125,7 +130,7 @@ class TestServer:
         mock_args.endpoint = 'https://test.example.com'
         mock_args.service = 'test-service'
         mock_args.region = 'us-east-1'
-        mock_args.profile = 'test-profile'
+        mock_args.profiles = ['test-profile']
         mock_args.read_only = False
         mock_args.retries = 0  # No retries
         mock_args.metadata = {'AWS_REGION': 'eu-west-1', 'CUSTOM_KEY': 'custom_value'}
@@ -199,7 +204,7 @@ class TestServer:
         mock_args.endpoint = 'https://test.example.com'
         mock_args.service = 'test-service'
         mock_args.region = 'ap-southeast-1'
-        mock_args.profile = None
+        mock_args.profiles = None
         mock_args.read_only = False
         mock_args.retries = 0
         mock_args.metadata = None  # No metadata provided
@@ -254,7 +259,7 @@ class TestServer:
         mock_args.endpoint = 'https://test.example.com'
         mock_args.service = 'test-service'
         mock_args.region = 'us-west-1'
-        mock_args.profile = None
+        mock_args.profiles = None
         mock_args.read_only = False
         mock_args.retries = 0
         mock_args.metadata = {'CUSTOM_KEY': 'custom_value', 'ANOTHER_KEY': 'another_value'}
@@ -332,7 +337,7 @@ class TestServer:
         assert args.endpoint == 'https://test.example.com'
         assert args.service is None
         assert args.region is None
-        assert args.profile is None
+        assert args.profiles is None
         assert args.read_only is False
         assert args.log_level == 'ERROR'
         assert args.retries == 0
@@ -448,3 +453,237 @@ class TestServer:
                 server_module.main()
             # Since we're not actually running as __main__, we just verify the structure exists
             assert mock_main.call_count == 0  # Should not be called in test context
+
+
+class TestProfileDedup:
+    """Tests for profile deduplication in run_proxy."""
+
+    def test_duplicate_profiles_are_deduped(self):
+        """Duplicate profiles in the list are removed."""
+        mcp = Mock()
+        result = add_profile_override_middleware(
+            mcp,
+            all_profiles=['default', 'dev', 'dev', 'staging', 'staging'],
+            default_profile='default',
+            service='test',
+            region='us-east-1',
+            metadata={},
+            timeout=httpx.Timeout(30),
+            endpoint='https://test.example.com',
+        )
+        assert result is not None
+        assert result._allowed_profiles == {'default', 'dev', 'staging'}
+
+    def test_default_profile_included_in_allowed_list(self):
+        """Default profile is included in the allowed profiles."""
+        mcp = Mock()
+        result = add_profile_override_middleware(
+            mcp,
+            all_profiles=['default', 'dev', 'staging'],
+            default_profile='default',
+            service='test',
+            region='us-east-1',
+            metadata={},
+            timeout=httpx.Timeout(30),
+            endpoint='https://test.example.com',
+        )
+        assert result is not None
+        assert 'default' in result._allowed_profiles
+        assert result._default_profile == 'default'
+
+    def test_single_profile_no_middleware(self):
+        """Single profile means no switching needed, no middleware."""
+        mcp = Mock()
+        result = add_profile_override_middleware(
+            mcp,
+            all_profiles=['default'],
+            default_profile='default',
+            service='test',
+            region='us-east-1',
+            metadata={},
+            timeout=httpx.Timeout(30),
+            endpoint='https://test.example.com',
+        )
+        assert result is None
+        mcp.add_middleware.assert_not_called()
+
+
+class TestEnvVarProfiles:
+    """Tests for AWS_MCP_PROXY_PROFILES env var support."""
+
+    @patch.dict('os.environ', {'AWS_MCP_PROXY_PROFILES': 'default dev staging'})
+    @patch('sys.argv', ['test', 'https://test.example.com'])
+    def test_env_var_parsed_when_no_profile_flag(self):
+        """Env var is read when --profile is not passed."""
+        args = parse_args()
+        assert args.profiles is None  # No CLI profiles
+
+    @patch.dict('os.environ', {'AWS_MCP_PROXY_PROFILES': 'default dev staging'})
+    @patch('sys.argv', ['test', 'https://test.example.com', '--profile', 'explicit'])
+    def test_env_var_takes_precedence_over_profile_flag(self):
+        """AWS_MCP_PROXY_PROFILES env var takes precedence over --profile flag."""
+        args = parse_args()
+        # args.profiles will have the CLI value, but run_proxy checks env var first
+        assert args.profiles == ['explicit']
+
+    @patch.dict('os.environ', {'AWS_MCP_PROXY_PROFILES': ''})
+    @patch('sys.argv', ['test', 'https://test.example.com'])
+    def test_empty_env_var_ignored(self):
+        """Empty env var is treated as unset."""
+        args = parse_args()
+        assert args.profiles is None
+
+    @patch.dict('os.environ', {'AWS_MCP_PROXY_PROFILES': '  dev   staging  '})
+    @patch('sys.argv', ['test', 'https://test.example.com'])
+    def test_env_var_handles_extra_whitespace(self):
+        """Extra whitespace in env var is handled correctly."""
+        # The env var parsing happens in run_proxy, not parse_args
+        # Test the split logic directly
+        env_profiles = os.environ.get('AWS_MCP_PROXY_PROFILES')
+        profiles = env_profiles.split() if env_profiles else []
+        assert profiles == ['dev', 'staging']
+
+
+class TestFix2EnvVarPrecedence:
+    """Fix #2: AWS_MCP_PROXY_PROFILES takes precedence over AWS_PROFILE."""
+
+    @patch.dict(
+        'os.environ',
+        {
+            'AWS_MCP_PROXY_PROFILES': 'admin dev staging',
+            'AWS_PROFILE': 'some-other-profile',
+        },
+    )
+    @patch('mcp_proxy_for_aws.server.AWSMCPProxyClientFactory')
+    @patch('mcp_proxy_for_aws.server.create_transport_with_sigv4')
+    @patch('mcp_proxy_for_aws.server.FastMCPProxy')
+    @patch('mcp_proxy_for_aws.server.determine_aws_region')
+    @patch('mcp_proxy_for_aws.server.determine_service_name')
+    @patch('mcp_proxy_for_aws.server.add_tool_filtering_middleware')
+    @pytest.mark.asyncio
+    async def test_env_var_profiles_wins_over_aws_profile(
+        self,
+        mock_add_filtering,
+        mock_determine_service,
+        mock_determine_region,
+        mock_fastmcp_proxy,
+        mock_create_transport,
+        mock_client_factory_class,
+    ):
+        """AWS_MCP_PROXY_PROFILES is used even when AWS_PROFILE sets args.profiles."""
+        mock_args = Mock()
+        mock_args.endpoint = 'https://test.example.com'
+        mock_args.service = 'test-service'
+        mock_args.region = 'us-east-1'
+        # AWS_PROFILE would set this via cli.py default
+        mock_args.profiles = ['some-other-profile']
+        mock_args.read_only = False
+        mock_args.retries = 0
+        mock_args.metadata = None
+        mock_args.timeout = 180.0
+        mock_args.connect_timeout = 60.0
+        mock_args.read_timeout = 120.0
+        mock_args.write_timeout = 180.0
+        mock_args.log_level = 'INFO'
+        mock_args.tool_timeout = 300.0
+        mock_args.disable_telemetry = False
+
+        mock_determine_service.return_value = 'test-service'
+        mock_determine_region.return_value = 'us-east-1'
+
+        mock_transport = Mock()
+        mock_create_transport.return_value = mock_transport
+
+        mock_client_factory = Mock()
+        mock_client_factory.disconnect = AsyncMock()
+        mock_client_factory_class.return_value = mock_client_factory
+
+        mock_proxy = Mock()
+        mock_proxy.run_async = AsyncMock()
+        mock_proxy.add_middleware = Mock()
+        mock_fastmcp_proxy.return_value = mock_proxy
+
+        await run_proxy(mock_args)
+
+        # Verify the middleware was created with profiles from AWS_MCP_PROXY_PROFILES, not AWS_PROFILE
+        middleware_calls = mock_proxy.add_middleware.call_args_list
+        for call in middleware_calls:
+            if isinstance(call[0][0], ProfileOverrideMiddleware):
+                middleware = call[0][0]
+                assert middleware._allowed_profiles == {'admin', 'dev', 'staging'}
+                assert middleware._default_profile == 'admin'
+                break
+        else:
+            pytest.fail('ProfileOverrideMiddleware not found in middleware calls')
+
+
+class TestEnvVarActivatesMiddleware:
+    """Test that AWS_MCP_PROXY_PROFILES env var activates the profile middleware in run_proxy."""
+
+    @patch.dict('os.environ', {'AWS_MCP_PROXY_PROFILES': 'default dev staging'})
+    @patch('mcp_proxy_for_aws.server.AWSMCPProxyClientFactory')
+    @patch('mcp_proxy_for_aws.server.create_transport_with_sigv4')
+    @patch('mcp_proxy_for_aws.server.FastMCPProxy')
+    @patch('mcp_proxy_for_aws.server.determine_aws_region')
+    @patch('mcp_proxy_for_aws.server.determine_service_name')
+    @patch('mcp_proxy_for_aws.server.add_tool_filtering_middleware')
+    @pytest.mark.asyncio
+    async def test_env_var_activates_profile_middleware(
+        self,
+        mock_add_filtering,
+        mock_determine_service,
+        mock_determine_region,
+        mock_fastmcp_proxy,
+        mock_create_transport,
+        mock_client_factory_class,
+    ):
+        """When AWS_MCP_PROXY_PROFILES is set and --profile is not, middleware is activated."""
+        mock_args = Mock()
+        mock_args.endpoint = 'https://test.example.com'
+        mock_args.service = 'test-service'
+        mock_args.region = 'us-east-1'
+        mock_args.profiles = None  # No --profile flag
+        mock_args.read_only = False
+        mock_args.retries = 0
+        mock_args.metadata = None
+        mock_args.timeout = 180.0
+        mock_args.connect_timeout = 60.0
+        mock_args.read_timeout = 120.0
+        mock_args.write_timeout = 180.0
+        mock_args.log_level = 'INFO'
+        mock_args.tool_timeout = 300.0
+        mock_args.disable_telemetry = False
+
+        mock_determine_service.return_value = 'test-service'
+        mock_determine_region.return_value = 'us-east-1'
+
+        mock_transport = Mock()
+        mock_create_transport.return_value = mock_transport
+
+        mock_client_factory = Mock()
+        mock_client_factory.disconnect = AsyncMock()
+        mock_client_factory_class.return_value = mock_client_factory
+
+        mock_proxy = Mock()
+        mock_proxy.run_async = AsyncMock()
+        mock_proxy.add_middleware = Mock()
+        mock_fastmcp_proxy.return_value = mock_proxy
+
+        await run_proxy(mock_args)
+
+        # Verify middleware was added (add_middleware called for: initialize, tool_error, logging, filtering, profile_override)
+        middleware_calls = mock_proxy.add_middleware.call_args_list
+        profile_middleware_added = any(
+            isinstance(call[0][0], ProfileOverrideMiddleware) for call in middleware_calls
+        )
+        assert profile_middleware_added, (
+            'ProfileOverrideMiddleware should be activated when AWS_MCP_PROXY_PROFILES is set'
+        )
+
+        # Verify the middleware has the correct profiles (all profiles including default)
+        for call in middleware_calls:
+            if isinstance(call[0][0], ProfileOverrideMiddleware):
+                middleware = call[0][0]
+                assert middleware._allowed_profiles == {'default', 'dev', 'staging'}
+                assert middleware._default_profile == 'default'
+                break

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -14,6 +14,7 @@
 
 """Tests for the mcp-proxy-for-aws Server."""
 
+import httpx
 from fastmcp.client.transports import ClientTransport
 from mcp_proxy_for_aws.server import (
     add_retry_middleware,
@@ -53,7 +54,7 @@ class TestServer:
         mock_args.endpoint = 'https://test.example.com'
         mock_args.service = 'test-service'
         mock_args.region = 'us-east-1'
-        mock_args.profile = None
+        mock_args.profiles = None
         mock_args.read_only = True
         mock_args.retries = 1
         mock_args.metadata = None
@@ -125,7 +126,7 @@ class TestServer:
         mock_args.endpoint = 'https://test.example.com'
         mock_args.service = 'test-service'
         mock_args.region = 'us-east-1'
-        mock_args.profile = 'test-profile'
+        mock_args.profiles = ['test-profile']
         mock_args.read_only = False
         mock_args.retries = 0  # No retries
         mock_args.metadata = {'AWS_REGION': 'eu-west-1', 'CUSTOM_KEY': 'custom_value'}
@@ -199,7 +200,7 @@ class TestServer:
         mock_args.endpoint = 'https://test.example.com'
         mock_args.service = 'test-service'
         mock_args.region = 'ap-southeast-1'
-        mock_args.profile = None
+        mock_args.profiles = None
         mock_args.read_only = False
         mock_args.retries = 0
         mock_args.metadata = None  # No metadata provided
@@ -254,7 +255,7 @@ class TestServer:
         mock_args.endpoint = 'https://test.example.com'
         mock_args.service = 'test-service'
         mock_args.region = 'us-west-1'
-        mock_args.profile = None
+        mock_args.profiles = None
         mock_args.read_only = False
         mock_args.retries = 0
         mock_args.metadata = {'CUSTOM_KEY': 'custom_value', 'ANOTHER_KEY': 'another_value'}
@@ -332,7 +333,7 @@ class TestServer:
         assert args.endpoint == 'https://test.example.com'
         assert args.service is None
         assert args.region is None
-        assert args.profile is None
+        assert args.profiles is None
         assert args.read_only is False
         assert args.log_level == 'ERROR'
         assert args.retries == 0
@@ -448,3 +449,49 @@ class TestServer:
                 server_module.main()
             # Since we're not actually running as __main__, we just verify the structure exists
             assert mock_main.call_count == 0  # Should not be called in test context
+
+
+class TestProfileDedup:
+    """Tests for profile deduplication in run_proxy."""
+
+    def test_duplicate_switch_profiles_are_deduped(self):
+        """Duplicate profiles in the switch list are removed."""
+        from mcp_proxy_for_aws.server import add_profile_override_middleware
+
+        mcp = Mock()
+        # If we pass duplicates, the middleware should only get unique ones
+        result = add_profile_override_middleware(
+            mcp,
+            switch_profiles=['dev', 'dev', 'staging', 'staging'],
+            service='test',
+            region='us-east-1',
+            metadata={},
+            timeout=httpx.Timeout(30),
+            endpoint='https://test.example.com',
+        )
+        assert result is not None
+        assert result._allowed_profiles == {'dev', 'staging'}
+
+    def test_default_profile_excluded_from_switch_list(self):
+        """If default profile appears in switch list, it's excluded."""
+        profiles = ['default', 'default', 'dev', 'staging']
+        default_profile = profiles[0]
+        switch_profiles = list(dict.fromkeys(p for p in profiles[1:] if p != default_profile))
+        assert switch_profiles == ['dev', 'staging']
+
+    def test_single_profile_no_middleware(self):
+        """Single profile means no switch profiles, no middleware."""
+        from mcp_proxy_for_aws.server import add_profile_override_middleware
+
+        mcp = Mock()
+        result = add_profile_override_middleware(
+            mcp,
+            switch_profiles=[],
+            service='test',
+            region='us-east-1',
+            metadata={},
+            timeout=httpx.Timeout(30),
+            endpoint='https://test.example.com',
+        )
+        assert result is None
+        mcp.add_middleware.assert_not_called()


### PR DESCRIPTION
Based on the work from #205 by @benjstoll. Adds ProfileOverrideMiddleware that allows routing individual tool calls through dedicated per-profile MCP connections via an `aws_profile` tool parameter.

## Summary

### Changes

- Added `ProfileOverrideMiddleware` in `mcp_proxy_for_aws/middleware/profile_switcher.py` that intercepts an `aws_profile` argument on any tool call, validates it against an allowlist, and routes the request through a dedicated per-profile MCP client with its own SigV4-signed transport.
- `--profile` accepts multiple values. First is the default, rest enable per-call switching (e.g., `--profile default dev staging`).
- Wired the middleware into `server.py` with proper lifecycle management (lazy client creation, graceful shutdown of per-profile connections in the finally block).
- Added unit tests covering tool schema injection, pass-through behavior, disallowed profiles, argument stripping, connection/tool-call error handling, and client disconnect logic.
- Updated README.md with the new parameter in the configuration table and a "Multi-account access" section.

### Additional changes on top of #205

- Unified `--profile` to accept multiple values, removed `--allow-switch-profile` flag
- Renamed `proxy_profile` to `aws_profile` — the agent doesn't need to know about the proxy
- Added `ToolError` raises on failures instead of silent fallbacks
- Added asyncio lock to prevent duplicate profile client creation
- Added warning when a tool's `aws_profile` parameter is shadowed by the override
- Added dedup logic: duplicate profiles removed, default excluded from switch list
- Fixed pyright compatibility for fastmcp.tools import path
- Used `dest='profiles'` in argparse for clarity

## Closes

- #172
- #119
- #193
