### PR TITLE
test: rename retrieve_agent_sop to retrieve_skill

### DIFF
--- a/tests/integ/test_aws_mcp_server_happy_path.py
+++ b/tests/integ/test_aws_mcp_server_happy_path.py
@@ -104,7 +104,7 @@ async def test_aws_mcp_tools(aws_mcp_client: fastmcp.Client, tool_name: str, par
 @pytest.mark.asyncio(loop_scope='module')
 async def test_aws_mcp_tools_retrieve_skill(aws_mcp_client: fastmcp.Client):
     """Test aws___retrieve_skill by retrieving a skill."""
-    test_skill = 'create_production_vpc_multi_az'
+    test_skill = 'creating-production-vpc-multi-az'
     logger.info('Testing with skill: %s', test_skill)
 
     response = await aws_mcp_client.call_tool('aws___retrieve_skill', {'skill_name': test_skill})

--- a/tests/integ/test_aws_mcp_server_happy_path.py
+++ b/tests/integ/test_aws_mcp_server_happy_path.py
@@ -102,13 +102,11 @@ async def test_aws_mcp_tools(aws_mcp_client: fastmcp.Client, tool_name: str, par
 
 
 @pytest.mark.asyncio(loop_scope='module')
-async def test_aws_mcp_tools_retrieve_agent_sop(aws_mcp_client: fastmcp.Client):
-    """Test aws___retrieve_agent_sop by retrieving the list of available SOPs."""
-    test_script = 'create_production_vpc_multi_az'
-    logger.info('Testing with SOP: %s', test_script)
+async def test_aws_mcp_tools_retrieve_skill(aws_mcp_client: fastmcp.Client):
+    """Test aws___retrieve_skill by retrieving a skill."""
+    test_skill = 'create_production_vpc_multi_az'
+    logger.info('Testing with skill: %s', test_skill)
 
-    response = await aws_mcp_client.call_tool(
-        'aws___retrieve_agent_sop', {'sop_name': test_script}
-    )
+    response = await aws_mcp_client.call_tool('aws___retrieve_skill', {'skill_name': test_skill})
 
     verify_response_content(response)


### PR DESCRIPTION
Replace aws___retrieve_agent_sop with aws___retrieve_skill in integration tests to match the renamed tool.

## Summary

### Changes

The `aws___retrieve_agent_sop` tool was renamed to `aws___retrieve_skill` on the AWS MCP Server. This PR updates the integration test to call the new tool name (`aws___retrieve_skill`) with the updated parameter name (`skill_name` instead of `sop_name`).

### User experience

No user-facing change — this is a test-only update to keep integration tests passing against the current server API.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

Ran integ. tests locally to verify this test works.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.