### PR TITLE
fix: resolve AWS credentials off the event loop

### DIFF
--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -145,9 +145,11 @@ class SessionHolder:
     async def async_refresh_if_needed(self) -> None:
         """Async version of refresh_if_needed that offloads blocking I/O to a thread.
 
-        For profiles that use assumed IAM roles (chained credentials), session
-        creation involves a blocking STS AssumeRole call.  Running that on the
-        event loop blocks all other coroutines and causes timeouts.
+        Defensive counterpart to :meth:`async_get_credentials`.  While the
+        primary blocking path is ``get_credentials()`` (which triggers a
+        synchronous STS call for assumed-role profiles), session recreation
+        via ``create_aws_session()`` may also perform blocking I/O in the
+        future.  Offloading it to a thread keeps the event loop safe.
         """
         if not self._needs_refresh:
             return

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -14,6 +14,7 @@
 
 """SigV4 Helper for AWS request signing functionality."""
 
+import asyncio
 import boto3
 import httpx
 import json
@@ -140,6 +141,27 @@ class SessionHolder:
             logger.warning(
                 'Failed to create fresh AWS session, keeping current session', exc_info=True
             )
+
+    async def async_refresh_if_needed(self) -> None:
+        """Async version of refresh_if_needed that offloads blocking I/O to a thread.
+
+        For profiles that use assumed IAM roles (chained credentials), session
+        creation involves a blocking STS AssumeRole call.  Running that on the
+        event loop blocks all other coroutines and causes timeouts.
+        """
+        if not self._needs_refresh:
+            return
+        await asyncio.to_thread(self.refresh_if_needed)
+
+    async def async_get_credentials(self):
+        """Resolve credentials without blocking the event loop.
+
+        ``boto3.Session.get_credentials()`` may trigger a synchronous STS
+        ``AssumeRole`` call when the profile uses chained credentials.
+        Offloading the call to a worker thread prevents the event loop from
+        stalling.
+        """
+        return await asyncio.to_thread(self.session.get_credentials)
 
 
 def create_sigv4_client(
@@ -289,10 +311,14 @@ async def _sign_request_hook(
     # Refresh session if a previous request got an auth error.
     # Done here (at signing time) so the new session reads credentials
     # that the user may have refreshed since the error occurred.
-    session_holder.refresh_if_needed()
+    # Use async variant to avoid blocking the event loop when the profile
+    # requires an STS AssumeRole call (chained credentials).
+    await session_holder.async_refresh_if_needed()
 
-    # Get AWS credentials from the session
-    credentials = session_holder.session.get_credentials()
+    # Get AWS credentials from the session.
+    # Offloaded to a thread because get_credentials() may trigger a
+    # synchronous STS call for assumed-role profiles.
+    credentials = await session_holder.async_get_credentials()
 
     # Create SigV4 auth and use its signing logic
     auth = SigV4HTTPXAuth(credentials, service, region)

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -14,6 +14,7 @@
 
 """SigV4 Helper for AWS request signing functionality."""
 
+import asyncio
 import boto3
 import httpx
 import json
@@ -255,6 +256,21 @@ async def _handle_error_response(response: httpx.Response) -> None:
                 )
 
 
+def _resolve_credentials(profile: Optional[str] = None):
+    """Resolve AWS credentials synchronously (intended for asyncio.to_thread).
+
+    Calls get_frozen_credentials() to eagerly resolve any deferred
+    credential provider (e.g. STS AssumeRole) inside the worker thread,
+    preventing lazy resolution from blocking the event loop later when
+    SigV4Auth reads the access_key / secret_key attributes.
+    """
+    session = create_aws_session(profile)
+    credentials = session.get_credentials()
+    if credentials is None:
+        return None
+    return credentials.get_frozen_credentials()
+
+
 async def _sign_request_hook(
     region: str,
     service: str,
@@ -280,8 +296,11 @@ async def _sign_request_hook(
 
     # Always read fresh credentials from disk so account switches
     # and credential refreshes take effect immediately.
-    session = create_aws_session(profile)
-    credentials = session.get_credentials()
+    # Offloaded to a thread because create_aws_session() and
+    # get_credentials() may trigger synchronous I/O (e.g. STS
+    # AssumeRole for chained credentials) that would block the
+    # event loop.
+    credentials = await asyncio.to_thread(_resolve_credentials, profile)
 
     if credentials is None:
         if skip_auth:

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -24,7 +24,7 @@ from mcp_proxy_for_aws.sigv4_helper import (
     _inject_metadata_hook,
     _sign_request_hook,
 )
-from unittest.mock import MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 
 def create_request_with_sigv4_headers(
@@ -55,8 +55,15 @@ def create_mock_session():
 
 def create_mock_session_holder():
     """Helper to create a mocked SessionHolder."""
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = 'test-access-key'
+    mock_credentials.secret_key = 'test-secret-key'
+    mock_credentials.token = 'test-token'
+
     holder = MagicMock(spec=SessionHolder)
     holder.session = create_mock_session()
+    holder.async_refresh_if_needed = AsyncMock()
+    holder.async_get_credentials = AsyncMock(return_value=mock_credentials)
     return holder
 
 
@@ -402,14 +409,14 @@ class TestSignRequestHook:
 
     @pytest.mark.asyncio
     async def test_sign_request_hook_calls_refresh_if_needed(self):
-        """Signing hook calls refresh_if_needed before signing."""
+        """Signing hook calls async_refresh_if_needed before signing."""
         holder = create_mock_session_holder()
         request_body = b'{"test": "data"}'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
 
         await _sign_request_hook('us-east-1', 'execute-api', holder, request)
 
-        holder.refresh_if_needed.assert_called_once()
+        holder.async_refresh_if_needed.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_sign_request_hook_signs_request(self):

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -14,16 +14,18 @@
 
 """Unit tests for hooks module."""
 
+import asyncio
 import httpx
 import json
 import pytest
+import threading
 from functools import partial
 from mcp_proxy_for_aws.sigv4_helper import (
     _handle_error_response,
     _inject_metadata_hook,
     _sign_request_hook,
 )
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 
 def create_request_with_sigv4_headers(
@@ -48,6 +50,7 @@ def create_mock_session():
     mock_credentials.access_key = 'test-access-key'
     mock_credentials.secret_key = 'test-secret-key'
     mock_credentials.token = 'test-token'
+    mock_credentials.get_frozen_credentials.return_value = mock_credentials
     mock_session.get_credentials.return_value = mock_credentials
     return mock_session
 
@@ -501,3 +504,87 @@ class TestSignRequestHook:
         await _sign_request_hook('us-east-1', 'execute-api', None, True, request)
 
         mock_auth_class.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sign_request_hook_uses_to_thread(self, mock_create_session):
+        """Credential resolution is offloaded via asyncio.to_thread."""
+        mock_creds = MagicMock()
+        mock_creds.access_key = 'test-access-key'
+        mock_creds.secret_key = 'test-secret-key'
+        mock_creds.token = 'test-token'
+
+        request_body = b'{"test": "data"}'
+        request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
+
+        with patch('mcp_proxy_for_aws.sigv4_helper.asyncio') as mock_asyncio:
+            mock_asyncio.to_thread = AsyncMock(return_value=mock_creds)
+            await _sign_request_hook('us-east-1', 'execute-api', 'my-profile', False, request)
+
+            mock_asyncio.to_thread.assert_awaited_once()
+            args = mock_asyncio.to_thread.call_args
+            from mcp_proxy_for_aws.sigv4_helper import _resolve_credentials
+
+            assert args[0][0] is _resolve_credentials
+            assert args[0][1] == 'my-profile'
+
+    @pytest.mark.asyncio
+    async def test_sign_request_hook_does_not_block_event_loop(self, mock_create_session):
+        """Event loop remains responsive while credentials are resolved in a thread."""
+        started = threading.Event()
+        release = threading.Event()
+
+        mock_creds = MagicMock()
+        mock_creds.access_key = 'test-access-key'
+        mock_creds.secret_key = 'test-secret-key'
+        mock_creds.token = 'test-token'
+
+        def blocking_resolve(profile=None):
+            started.set()
+            release.wait(timeout=5)
+            return mock_creds
+
+        ticks = []
+
+        async def ticker():
+            while not release.is_set():
+                ticks.append(True)
+                await asyncio.sleep(0.01)
+
+        with patch(
+            'mcp_proxy_for_aws.sigv4_helper._resolve_credentials',
+            side_effect=blocking_resolve,
+        ):
+            request_body = b'{"test": "data"}'
+            request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
+
+            ticker_task = asyncio.create_task(ticker())
+            sign_task = asyncio.create_task(
+                _sign_request_hook('us-east-1', 'execute-api', None, False, request)
+            )
+
+            # Wait for the blocking function to start in the thread
+            # (poll instead of asyncio.to_thread to avoid consuming threadpool)
+            for _ in range(200):
+                if started.is_set():
+                    break
+                await asyncio.sleep(0.01)
+            assert started.is_set(), 'blocking_resolve did not start'
+
+            # Credential resolution is still in progress (offloaded to thread)
+            assert not sign_task.done(), 'Credential resolution did not remain offloaded'
+
+            ticks_after_start = len(ticks)
+            await asyncio.sleep(0.05)
+
+            # Event loop should still be responsive (ticker advanced while blocked)
+            assert len(ticks) > ticks_after_start, (
+                'Event loop was blocked during credential resolution'
+            )
+
+            release.set()
+            await sign_task
+            ticker_task.cancel()
+            try:
+                await ticker_task
+            except asyncio.CancelledError:
+                pass

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -517,7 +517,11 @@ class TestSignRequestHook:
 
     @pytest.mark.asyncio
     async def test_sign_request_hook_does_not_block_event_loop(self):
-        """Test that blocking credential resolution runs in a thread."""
+        """Test that the event loop stays responsive while credentials resolve.
+
+        A ticker coroutine runs alongside the signing hook.  If get_credentials()
+        blocked the loop, the ticker would not advance during the sleep.
+        """
         import asyncio
         import time
 
@@ -527,7 +531,7 @@ class TestSignRequestHook:
         mock_credentials.token = None
 
         def slow_get_credentials():
-            time.sleep(0.1)
+            time.sleep(0.3)
             return mock_credentials
 
         mock_session = Mock()
@@ -541,10 +545,22 @@ class TestSignRequestHook:
             headers={'Host': 'example.com'},
         )
 
-        # Should complete without blocking — the event loop stays responsive
-        await asyncio.wait_for(
-            _sign_request_hook('us-east-1', 'aws-mcp', holder, request),
-            timeout=5.0,
-        )
+        tick_count = 0
 
+        async def ticker():
+            nonlocal tick_count
+            while True:
+                await asyncio.sleep(0.05)
+                tick_count += 1
+
+        ticker_task = asyncio.create_task(ticker())
+        try:
+            await _sign_request_hook('us-east-1', 'aws-mcp', holder, request)
+        finally:
+            ticker_task.cancel()
+
+        # If get_credentials() blocked the loop, ticker would not have advanced
+        assert tick_count >= 2, (
+            f'ticker only ticked {tick_count} times — event loop was likely blocked'
+        )
         assert 'Authorization' in request.headers

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -25,10 +25,11 @@ from mcp_proxy_for_aws.sigv4_helper import (
     SessionHolder,
     SigV4HTTPXAuth,
     _sanitize_headers,
+    _sign_request_hook,
     create_aws_session,
     create_sigv4_client,
 )
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 
 class TestSigV4HTTPXAuth:
@@ -369,6 +370,44 @@ class TestSessionHolder:
         assert 'Failed to create fresh AWS session' in caplog.text
         assert 'session creation boom' in caplog.text
 
+    @pytest.mark.asyncio
+    async def test_async_refresh_if_needed_noop_when_not_marked(self):
+        """async_refresh_if_needed does nothing when not marked."""
+        mock_session = Mock()
+        holder = SessionHolder(mock_session)
+
+        await holder.async_refresh_if_needed()
+
+        assert holder.session is mock_session
+
+    @pytest.mark.asyncio
+    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
+    async def test_async_refresh_if_needed_creates_new_session_when_marked(self, mock_create):
+        """async_refresh_if_needed replaces session after mark_needs_refresh."""
+        old_session = Mock()
+        new_session = Mock()
+        mock_create.return_value = new_session
+        holder = SessionHolder(old_session, profile='my-profile')
+
+        holder.mark_needs_refresh()
+        await holder.async_refresh_if_needed()
+
+        mock_create.assert_called_once_with('my-profile')
+        assert holder.session is new_session
+
+    @pytest.mark.asyncio
+    async def test_async_get_credentials_delegates_to_session(self):
+        """async_get_credentials calls session.get_credentials in a thread."""
+        mock_creds = Mock()
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = mock_creds
+        holder = SessionHolder(mock_session)
+
+        result = await holder.async_get_credentials()
+
+        mock_session.get_credentials.assert_called_once()
+        assert result is mock_creds
+
 
 class TestSanitizeHeaders:
     """Test cases for the _sanitize_headers function."""
@@ -442,3 +481,70 @@ class TestSanitizeHeaders:
         assert 'authorization' in SENSITIVE_HEADERS
         assert 'x-amz-security-token' in SENSITIVE_HEADERS
         assert 'x-amz-date' in SENSITIVE_HEADERS
+
+
+class TestSignRequestHook:
+    """Test cases for the _sign_request_hook function."""
+
+    @pytest.mark.asyncio
+    async def test_sign_request_hook_uses_async_credential_resolution(self):
+        """Test that _sign_request_hook resolves credentials asynchronously."""
+        mock_credentials = Mock()
+        mock_credentials.access_key = 'test_access_key'
+        mock_credentials.secret_key = 'test_secret_key'
+        mock_credentials.token = 'test_token'
+
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = mock_credentials
+        holder = SessionHolder(mock_session)
+
+        # Spy on the async methods to verify they are called
+        holder.async_refresh_if_needed = AsyncMock()
+        holder.async_get_credentials = AsyncMock(return_value=mock_credentials)
+
+        request = httpx.Request(
+            'POST',
+            'https://example.com/mcp',
+            content=b'{"jsonrpc":"2.0"}',
+            headers={'Host': 'example.com'},
+        )
+
+        await _sign_request_hook('us-east-1', 'aws-mcp', holder, request)
+
+        holder.async_refresh_if_needed.assert_awaited_once()
+        holder.async_get_credentials.assert_awaited_once()
+        assert 'Authorization' in request.headers
+
+    @pytest.mark.asyncio
+    async def test_sign_request_hook_does_not_block_event_loop(self):
+        """Test that blocking credential resolution runs in a thread."""
+        import asyncio
+        import time
+
+        mock_credentials = Mock()
+        mock_credentials.access_key = 'test_access_key'
+        mock_credentials.secret_key = 'test_secret_key'
+        mock_credentials.token = None
+
+        def slow_get_credentials():
+            time.sleep(0.1)
+            return mock_credentials
+
+        mock_session = Mock()
+        mock_session.get_credentials.side_effect = slow_get_credentials
+        holder = SessionHolder(mock_session)
+
+        request = httpx.Request(
+            'POST',
+            'https://example.com/mcp',
+            content=b'{"jsonrpc":"2.0"}',
+            headers={'Host': 'example.com'},
+        )
+
+        # Should complete without blocking — the event loop stays responsive
+        await asyncio.wait_for(
+            _sign_request_hook('us-east-1', 'aws-mcp', holder, request),
+            timeout=5.0,
+        )
+
+        assert 'Authorization' in request.headers


### PR DESCRIPTION
## Summary

Offload the synchronous `create_aws_session()` + `get_credentials()` call
in `_sign_request_hook` to `asyncio.to_thread()`, preventing the event loop
from blocking when the AWS profile uses chained credentials (e.g. STS AssumeRole).

### What changed

- Added `_resolve_credentials()` helper that calls `create_aws_session()`,
  `get_credentials()`, and `get_frozen_credentials()` — all inside a worker thread
- `_sign_request_hook` now awaits `asyncio.to_thread(_resolve_credentials, profile)`
  instead of calling session methods synchronously

### Post-#294 adaptation

`SessionHolder` was removed in #294 (v1.6.0). This PR is now based on
the current `main` and no longer carries any `SessionHolder`-related code.
The change wraps the per-request fresh-session credential read instead.

### What is NOT changed

- `_handle_error_response` — upstream signature maintained
- `create_sigv4_client` — upstream signature maintained
- `_patch_credential_process_stdin()` — upstream addition preserved
- `SigV4HTTPXAuth` — no changes

### Tests

- Verify `_resolve_credentials` is called via `asyncio.to_thread`
- Verify event loop remains responsive during credential resolution (`threading.Event`-based, less timing-sensitive)
- All existing upstream unit tests pass unchanged

Partially addresses #176.