### PR TITLE
fix: update negative integ test

### DIFF
--- a/tests/integ/test_aws_mcp_server_negative.py
+++ b/tests/integ/test_aws_mcp_server_negative.py
@@ -67,7 +67,7 @@ async def test_expired_credentials():
 
     try:
         async with expired_client:
-            response = await expired_client.call_tool('aws___list_regions')
+            response = await expired_client.call_tool('aws___call_aws')
             logger.info('Tool call completed without exception. Response: %s', response)
     except Exception as e:
         exception_raised = True


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

`aws___list_regions` is now unauthenticated so expired credentials are ignored. Replacing the test with `aws___call_aws` which does require authentication.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
