### PR TITLE
docs: add --skip-auth flag documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ docker build -t mcp-proxy-for-aws .
 | `--read-timeout`	    | Set desired read timeout in seconds	                                                                                                                                                                                                    | 120	                                                                        |No	|
 | `--write-timeout`	   | Set desired write timeout in seconds	                                                                                                                                                                                                   | 180	                                                                        |No	|
 | `--tool-timeout`	   | Maximum seconds a tool call may take before being cancelled. When set, returns a graceful error to the agent instead of hanging indefinitely	                                                                                             | 300	                                                                    |No	|
+| `--skip-auth`         | Skip request signing when AWS credentials are unavailable instead of failing                                                                                                                                                             | `False`                                                                     |No	|
 | `--disable-telemetry` | Disables telemetry data collection                                                                                                                                                                                                      | `False`                                                                     |No	|
 
 ### Optional Environment Variables
@@ -357,6 +358,16 @@ If your credentials do expire during a session, the proxy will automatically det
 
 ### Client hangs on tool calls
 If your MCP client hangs waiting for a tool call response (e.g., due to an unresponsive endpoint), use `--tool-timeout` to set a maximum duration in seconds for each tool call. When the timeout is exceeded, the proxy returns a graceful error to the agent instead of hanging indefinitely.
+
+### Unsigned requests
+
+By default, the proxy signs all outgoing requests with [SigV4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html) using your local AWS credentials. If you need to connect to an MCP endpoint that does not require SigV4 credentials (e.g., a local development server or a publicly accessible endpoint), use the `--skip-auth` flag:
+
+```bash
+uvx mcp-proxy-for-aws@latest https://my-endpoint.example.com/mcp --skip-auth
+```
+
+When `--skip-auth` is set, the proxy sends requests without signing them if AWS credentials are unavailable. If credentials _are_ available, requests are still signed as usual — the flag only changes behavior when credentials cannot be resolved.
 
 ## Development & Contributing
 


### PR DESCRIPTION
## Summary

### Changes

- Add `--skip-auth` to the configuration parameters table in README
- Add an "Unsigned requests" section under Troubleshooting explaining how to connect to endpoints that don't require SigV4 credentials

### User experience

Users can now find documentation for the `--skip-auth` flag directly in the README, including when and how to use it for endpoints that don't require AWS IAM authentication.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.