### PR TITLE
bump: version 1.4.2 → 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v1.5.0 (2026-05-22)
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ members = [
 name = "mcp-proxy-for-aws"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "1.4.2"
+version = "1.5.0"
 
 description = "MCP Proxy for AWS"
 readme = "README.md"


### PR DESCRIPTION
## Summary

### Changes

- Bump version from 1.4.2 to 1.5.0
- Move unreleased changelog entry (`--skip-auth` flag) into v1.5.0 section

### User experience

New minor release including the `--skip-auth` flag for unsigned requests when AWS credentials are unavailable.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.