### PR TITLE
fix: always read fresh credentials from disk on every request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Always read fresh credentials from disk on every request instead of caching and refreshing reactively on auth errors (#294)
+
 ## v1.5.0 (2026-05-22)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ For long-running sessions, consider using long-lived credentials:
 - Use an AWS profile via `--profile`
 - Use IAM Identity Center and run `aws sso login` before starting the proxy
 
-If your credentials do expire during a session, the proxy will automatically detect the auth failure and pick up refreshed credentials on the next request — no restart required. Simply refresh your credentials (e.g., `aws sso login`) and retry.
+The proxy reads fresh credentials from disk on every request, so credential refreshes and account switches take effect immediately — no restart or retry required. Simply refresh your credentials (e.g., `aws sso login`) and the next request will use them.
 
 ### Client hangs on tool calls
 If your MCP client hangs waiting for a tool call response (e.g., due to an unresponsive endpoint), use `--tool-timeout` to set a maximum duration in seconds for each tool call. When the timeout is exceeded, the proxy returns a graceful error to the agent instead of hanging indefinitely.

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -111,27 +111,10 @@ def create_aws_session(profile: Optional[str] = None) -> boto3.Session:
     return session
 
 
-class SessionHolder:
-    """Provides fresh boto3 sessions so every request reads current credentials from disk.
-
-    Instead of caching a session and refreshing reactively on auth errors,
-    this always creates a new session so account switches and credential
-    refreshes take effect immediately.
-    """
-
-    def __init__(self, profile: Optional[str] = None) -> None:
-        """Initialize SessionHolder with the given profile."""
-        self._profile = profile
-
-    def get_session(self) -> boto3.Session:
-        """Create and return a fresh boto3 session reading current credentials from disk."""
-        return create_aws_session(self._profile)
-
-
 def create_sigv4_client(
     service: str,
     region: str,
-    session_holder: SessionHolder,
+    profile: Optional[str] = None,
     timeout: Optional[httpx.Timeout] = None,
     headers: Optional[Dict[str, str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
@@ -144,8 +127,7 @@ def create_sigv4_client(
     Args:
         service: AWS service name for SigV4 signing
         region: AWS region for SigV4 signing
-        session_holder: SessionHolder that provides the current boto3 session
-            and can refresh it on credential errors
+        profile: AWS profile name for credentials (optional)
         timeout: Timeout configuration for the HTTP client
         headers: Headers to include in requests
         metadata: Metadata to inject into MCP _meta field
@@ -189,27 +171,23 @@ def create_sigv4_client(
     return httpx.AsyncClient(
         **client_kwargs,
         event_hooks={
-            'response': [partial(_handle_error_response, session_holder)],
+            'response': [_handle_error_response],
             'request': [
                 partial(_inject_metadata_hook, metadata or {}),
-                partial(_sign_request_hook, region, service, session_holder, skip_auth),
+                partial(_sign_request_hook, region, service, profile, skip_auth),
             ],
         },
     )
 
 
-async def _handle_error_response(session_holder: SessionHolder, response: httpx.Response) -> None:
+async def _handle_error_response(response: httpx.Response) -> None:
     """Event hook to handle HTTP error responses and extract details.
 
     This function is called for every HTTP response to check for errors
     and provide more detailed error information when requests fail.
 
     Args:
-        session_holder: SessionHolder (unused, kept for hook signature compatibility)
         response: The HTTP response object
-
-    Raises:
-        No raises. let the mcp http client handle the errors.
     """
     if response.is_error:
         # warning only because the SDK logs error
@@ -252,7 +230,7 @@ async def _handle_error_response(session_holder: SessionHolder, response: httpx.
 async def _sign_request_hook(
     region: str,
     service: str,
-    session_holder: SessionHolder,
+    profile: Optional[str],
     skip_auth: bool,
     request: httpx.Request,
 ) -> None:
@@ -265,7 +243,7 @@ async def _sign_request_hook(
     Args:
         region: AWS region for SigV4 signing
         service: AWS service name for SigV4 signing
-        session_holder: Holder providing the current boto3 session (refreshed on auth errors)
+        profile: AWS profile name for credentials (optional)
         skip_auth: Whether to skip signing when credentials are unavailable
         request: The HTTP request object to sign (modified in-place)
     """
@@ -274,7 +252,7 @@ async def _sign_request_hook(
 
     # Always read fresh credentials from disk so account switches
     # and credential refreshes take effect immediately.
-    session = session_holder.get_session()
+    session = create_aws_session(profile)
     credentials = session.get_credentials()
 
     if credentials is None:

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -112,34 +112,20 @@ def create_aws_session(profile: Optional[str] = None) -> boto3.Session:
 
 
 class SessionHolder:
-    """Holds a boto3 session that can be refreshed on credential errors.
+    """Provides fresh boto3 sessions so every request reads current credentials from disk.
 
-    Wraps a boto3.Session so the signing hook always uses the current session,
-    and can create a fresh session when the previous request got an auth error.
+    Instead of caching a session and refreshing reactively on auth errors,
+    this always creates a new session so account switches and credential
+    refreshes take effect immediately.
     """
 
-    def __init__(self, session: boto3.Session, profile: Optional[str] = None) -> None:
-        """Initialize SessionHolder with the given session and optional profile."""
-        self.session = session
+    def __init__(self, profile: Optional[str] = None) -> None:
+        """Initialize SessionHolder with the given profile."""
         self._profile = profile
-        self._needs_refresh = False
 
-    def mark_needs_refresh(self) -> None:
-        """Mark that the next request should use a fresh session."""
-        self._needs_refresh = True
-
-    def refresh_if_needed(self) -> None:
-        """Create a fresh session if a previous request got an auth error."""
-        if not self._needs_refresh:
-            return
-        logger.info('Refreshing AWS session to pick up new credentials')
-        try:
-            self.session = create_aws_session(self._profile)
-            self._needs_refresh = False
-        except Exception:
-            logger.warning(
-                'Failed to create fresh AWS session, keeping current session', exc_info=True
-            )
+    def get_session(self) -> boto3.Session:
+        """Create and return a fresh boto3 session reading current credentials from disk."""
+        return create_aws_session(self._profile)
 
 
 def create_sigv4_client(
@@ -219,17 +205,13 @@ async def _handle_error_response(session_holder: SessionHolder, response: httpx.
     and provide more detailed error information when requests fail.
 
     Args:
-        session_holder: SessionHolder to refresh on credential errors
+        session_holder: SessionHolder (unused, kept for hook signature compatibility)
         response: The HTTP response object
 
     Raises:
         No raises. let the mcp http client handle the errors.
     """
     if response.is_error:
-        # Mark session for refresh so the next request picks up new credentials
-        if response.status_code in (401, 403):
-            session_holder.mark_needs_refresh()
-
         # warning only because the SDK logs error
         log_level = logging.WARNING
         if (
@@ -290,13 +272,10 @@ async def _sign_request_hook(
     # Set Content-Length for signing
     request.headers['Content-Length'] = str(len(request.content))
 
-    # Refresh session if a previous request got an auth error.
-    # Done here (at signing time) so the new session reads credentials
-    # that the user may have refreshed since the error occurred.
-    session_holder.refresh_if_needed()
-
-    # Get AWS credentials from the session
-    credentials = session_holder.session.get_credentials()
+    # Always read fresh credentials from disk so account switches
+    # and credential refreshes take effect immediately.
+    session = session_holder.get_session()
+    credentials = session.get_credentials()
 
     if credentials is None:
         if skip_auth:

--- a/mcp_proxy_for_aws/utils.py
+++ b/mcp_proxy_for_aws/utils.py
@@ -19,7 +19,7 @@ import httpx
 import logging
 import os
 from fastmcp.client.transports import StreamableHttpTransport
-from mcp_proxy_for_aws.sigv4_helper import SessionHolder, create_aws_session, create_sigv4_client
+from mcp_proxy_for_aws.sigv4_helper import SessionHolder, create_sigv4_client
 from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -91,10 +91,9 @@ def create_transport_with_sigv4(
     Returns:
         StreamableHttpTransport instance with SigV4 authentication
     """
-    # Create AWS session with a holder that can refresh on credential errors
-    logger.debug('Creating AWS session with profile: %s', profile)
-    session = create_aws_session(profile)
-    session_holder = SessionHolder(session, profile)
+    # Create session holder that reads fresh credentials on every request
+    logger.debug('Creating session holder with profile: %s', profile)
+    session_holder = SessionHolder(profile=profile)
 
     def client_factory(
         headers: Optional[Dict[str, str]] = None,

--- a/mcp_proxy_for_aws/utils.py
+++ b/mcp_proxy_for_aws/utils.py
@@ -19,7 +19,7 @@ import httpx
 import logging
 import os
 from fastmcp.client.transports import StreamableHttpTransport
-from mcp_proxy_for_aws.sigv4_helper import SessionHolder, create_sigv4_client
+from mcp_proxy_for_aws.sigv4_helper import create_sigv4_client
 from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -91,9 +91,6 @@ def create_transport_with_sigv4(
     Returns:
         StreamableHttpTransport instance with SigV4 authentication
     """
-    # Create session holder that reads fresh credentials on every request
-    logger.debug('Creating session holder with profile: %s', profile)
-    session_holder = SessionHolder(profile=profile)
 
     def client_factory(
         headers: Optional[Dict[str, str]] = None,
@@ -103,8 +100,8 @@ def create_transport_with_sigv4(
     ) -> httpx.AsyncClient:
         return create_sigv4_client(
             service=service,
-            session_holder=session_holder,
             region=region,
+            profile=profile,
             headers=headers,
             timeout=custom_timeout,
             metadata=metadata,

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -56,7 +56,7 @@ def create_mock_session():
 def create_mock_session_holder():
     """Helper to create a mocked SessionHolder."""
     holder = MagicMock(spec=SessionHolder)
-    holder.session = create_mock_session()
+    holder.get_session.return_value = create_mock_session()
     return holder
 
 
@@ -64,8 +64,8 @@ class TestHandleErrorResponse:
     """Test cases for the _handle_error_response function."""
 
     @pytest.mark.asyncio
-    async def test_handle_error_response_marks_refresh_on_401(self):
-        """401 response marks the session holder for refresh."""
+    async def test_handle_error_response_logs_401(self):
+        """401 response is handled without error."""
         request = httpx.Request('POST', 'https://example.com/mcp')
         response = httpx.Response(
             status_code=401,
@@ -77,11 +77,9 @@ class TestHandleErrorResponse:
 
         await _handle_error_response(holder, response)
 
-        holder.mark_needs_refresh.assert_called_once()
-
     @pytest.mark.asyncio
-    async def test_handle_error_response_marks_refresh_on_403(self):
-        """403 response marks the session holder for refresh."""
+    async def test_handle_error_response_logs_403(self):
+        """403 response is handled without error."""
         request = httpx.Request('POST', 'https://example.com/mcp')
         response = httpx.Response(
             status_code=403,
@@ -92,25 +90,6 @@ class TestHandleErrorResponse:
         holder = create_mock_session_holder()
 
         await _handle_error_response(holder, response)
-
-        holder.mark_needs_refresh.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_handle_error_response_does_not_mark_refresh_on_other_errors(self):
-        """Non-auth error codes (400, 404, 500) do not mark refresh."""
-        for status_code in (400, 404, 500):
-            request = httpx.Request('POST', 'https://example.com/mcp')
-            response = httpx.Response(
-                status_code=status_code,
-                headers={'content-type': 'text/plain'},
-                content=b'Error',
-                request=request,
-            )
-            holder = create_mock_session_holder()
-
-            await _handle_error_response(holder, response)
-
-            holder.mark_needs_refresh.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_handle_error_response_with_json_error(self):
@@ -401,15 +380,15 @@ class TestSignRequestHook:
     """Test cases for sign_request_hook function."""
 
     @pytest.mark.asyncio
-    async def test_sign_request_hook_calls_refresh_if_needed(self):
-        """Signing hook calls refresh_if_needed before signing."""
+    async def test_sign_request_hook_calls_get_session(self):
+        """Signing hook calls get_session to read fresh credentials."""
         holder = create_mock_session_holder()
         request_body = b'{"test": "data"}'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
 
         await _sign_request_hook('us-east-1', 'execute-api', holder, False, request)
 
-        holder.refresh_if_needed.assert_called_once()
+        holder.get_session.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_sign_request_hook_signs_request(self):
@@ -482,7 +461,7 @@ class TestSignRequestHook:
     async def test_sign_request_hook_skips_signing_when_skip_auth(self):
         """Request is sent unsigned when credentials are unavailable and skip_auth is True."""
         holder = create_mock_session_holder()
-        holder.session.get_credentials.return_value = None
+        holder.get_session.return_value.get_credentials.return_value = None
 
         request_body = b'{"test": "data"}'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
@@ -497,7 +476,7 @@ class TestSignRequestHook:
     async def test_sign_request_hook_raises_when_no_credentials_and_no_skip_auth(self):
         """ValueError is raised when credentials are unavailable and skip_auth is False."""
         holder = create_mock_session_holder()
-        holder.session.get_credentials.return_value = None
+        holder.get_session.return_value.get_credentials.return_value = None
 
         request_body = b'{"test": "data"}'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
@@ -506,10 +485,10 @@ class TestSignRequestHook:
             await _sign_request_hook('us-east-1', 'execute-api', holder, False, request)
 
     @pytest.mark.asyncio
-    async def test_sign_request_hook_no_credentials_still_refreshes(self):
-        """refresh_if_needed is called even when credentials end up None."""
+    async def test_sign_request_hook_no_credentials_still_calls_get_session(self):
+        """get_session is called even when credentials end up None."""
         holder = create_mock_session_holder()
-        holder.session.get_credentials.return_value = None
+        holder.get_session.return_value.get_credentials.return_value = None
 
         request_body = b'test'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
@@ -517,14 +496,14 @@ class TestSignRequestHook:
         with pytest.raises(ValueError):
             await _sign_request_hook('us-east-1', 'execute-api', holder, False, request)
 
-        holder.refresh_if_needed.assert_called_once()
+        holder.get_session.assert_called_once()
 
     @pytest.mark.asyncio
     @patch('mcp_proxy_for_aws.sigv4_helper.SigV4HTTPXAuth')
     async def test_sign_request_hook_no_credentials_does_not_create_auth(self, mock_auth_class):
         """SigV4HTTPXAuth is never instantiated when credentials are None and skip_auth is True."""
         holder = create_mock_session_holder()
-        holder.session.get_credentials.return_value = None
+        holder.get_session.return_value.get_credentials.return_value = None
 
         request_body = b'test'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -19,7 +19,6 @@ import json
 import pytest
 from functools import partial
 from mcp_proxy_for_aws.sigv4_helper import (
-    SessionHolder,
     _handle_error_response,
     _inject_metadata_hook,
     _sign_request_hook,
@@ -53,13 +52,6 @@ def create_mock_session():
     return mock_session
 
 
-def create_mock_session_holder():
-    """Helper to create a mocked SessionHolder."""
-    holder = MagicMock(spec=SessionHolder)
-    holder.get_session.return_value = create_mock_session()
-    return holder
-
-
 class TestHandleErrorResponse:
     """Test cases for the _handle_error_response function."""
 
@@ -73,9 +65,8 @@ class TestHandleErrorResponse:
             content=b'Unauthorized',
             request=request,
         )
-        holder = create_mock_session_holder()
 
-        await _handle_error_response(holder, response)
+        await _handle_error_response(response)
 
     @pytest.mark.asyncio
     async def test_handle_error_response_logs_403(self):
@@ -87,9 +78,8 @@ class TestHandleErrorResponse:
             content=b'Forbidden',
             request=request,
         )
-        holder = create_mock_session_holder()
 
-        await _handle_error_response(holder, response)
+        await _handle_error_response(response)
 
     @pytest.mark.asyncio
     async def test_handle_error_response_with_json_error(self):
@@ -104,7 +94,7 @@ class TestHandleErrorResponse:
             request=request,
         )
 
-        await _handle_error_response(create_mock_session_holder(), response)
+        await _handle_error_response(response)
 
         # Verify response was read (content should be settled)
         assert response.is_stream_consumed
@@ -121,7 +111,7 @@ class TestHandleErrorResponse:
             request=request,
         )
 
-        await _handle_error_response(create_mock_session_holder(), response)
+        await _handle_error_response(response)
 
         # Verify response was read
         assert response.is_stream_consumed
@@ -138,7 +128,7 @@ class TestHandleErrorResponse:
             request=request,
         )
 
-        await _handle_error_response(create_mock_session_holder(), response)
+        await _handle_error_response(response)
 
         # Verify function completes without error for success responses
         assert response.status_code == 200
@@ -161,7 +151,7 @@ class TestHandleErrorResponse:
             )
         )
 
-        await _handle_error_response(create_mock_session_holder(), response)
+        await _handle_error_response(response)
 
         # Verify it handled the read failure gracefully (no exception raised)
         # The aread() was attempted (would have been called)
@@ -179,7 +169,7 @@ class TestHandleErrorResponse:
             request=request,
         )
 
-        await _handle_error_response(create_mock_session_holder(), response)
+        await _handle_error_response(response)
 
         # Verify response was read despite invalid JSON
         assert response.is_stream_consumed
@@ -376,32 +366,30 @@ class TestMetadataInjectionHook:
         assert modified_body['params']['_meta']['AWS_REGION'] == 'us-west-2'
 
 
+@patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
 class TestSignRequestHook:
     """Test cases for sign_request_hook function."""
 
     @pytest.mark.asyncio
-    async def test_sign_request_hook_calls_get_session(self):
-        """Signing hook calls get_session to read fresh credentials."""
-        holder = create_mock_session_holder()
+    async def test_sign_request_hook_creates_fresh_session(self, mock_create_session):
+        """Signing hook calls create_aws_session to read fresh credentials."""
+        mock_create_session.return_value = create_mock_session()
         request_body = b'{"test": "data"}'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
 
-        await _sign_request_hook('us-east-1', 'execute-api', holder, False, request)
+        await _sign_request_hook('us-east-1', 'execute-api', 'my-profile', False, request)
 
-        holder.get_session.assert_called_once()
+        mock_create_session.assert_called_once_with('my-profile')
 
     @pytest.mark.asyncio
-    async def test_sign_request_hook_signs_request(self):
+    async def test_sign_request_hook_signs_request(self, mock_create_session):
         """Test that sign_request_hook properly signs requests."""
-        holder = create_mock_session_holder()
-
-        region = 'us-east-1'
-        service = 'bedrock-agentcore'
+        mock_create_session.return_value = create_mock_session()
 
         request_body = json.dumps({'test': 'data'}).encode('utf-8')
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
 
-        await _sign_request_hook(region, service, holder, False, request)
+        await _sign_request_hook('us-east-1', 'bedrock-agentcore', None, False, request)
 
         assert 'authorization' in request.headers
         assert 'x-amz-date' in request.headers
@@ -409,45 +397,37 @@ class TestSignRequestHook:
         assert request.headers['content-length'] == str(len(request_body))
 
     @pytest.mark.asyncio
-    async def test_sign_request_hook_with_profile(self):
-        """Test that sign_request_hook uses session when provided."""
-        holder = create_mock_session_holder()
-
-        region = 'us-west-2'
-        service = 'execute-api'
+    async def test_sign_request_hook_with_profile(self, mock_create_session):
+        """Test that sign_request_hook passes profile to create_aws_session."""
+        mock_create_session.return_value = create_mock_session()
 
         request_body = b'test content'
         request = httpx.Request('POST', 'https://example.com/api', content=request_body)
 
-        await _sign_request_hook(region, service, holder, False, request)
+        await _sign_request_hook('us-west-2', 'execute-api', 'test-profile', False, request)
 
+        mock_create_session.assert_called_once_with('test-profile')
         assert 'authorization' in request.headers
         assert 'x-amz-date' in request.headers
 
     @pytest.mark.asyncio
-    async def test_sign_request_hook_sets_content_length(self):
+    async def test_sign_request_hook_sets_content_length(self, mock_create_session):
         """Test that sign_request_hook sets Content-Length header."""
-        holder = create_mock_session_holder()
-
-        region = 'eu-west-1'
-        service = 'lambda'
+        mock_create_session.return_value = create_mock_session()
 
         request_body = b'test content with specific length'
         request = httpx.Request('POST', 'https://example.com/api', content=request_body)
 
-        await _sign_request_hook(region, service, holder, False, request)
+        await _sign_request_hook('eu-west-1', 'lambda', None, False, request)
 
         assert request.headers['content-length'] == str(len(request_body))
 
     @pytest.mark.asyncio
-    async def test_sign_request_hook_with_partial_application(self):
+    async def test_sign_request_hook_with_partial_application(self, mock_create_session):
         """Test that sign_request_hook works with functools.partial."""
-        holder = create_mock_session_holder()
+        mock_create_session.return_value = create_mock_session()
 
-        region = 'ap-southeast-1'
-        service = 'execute-api'
-
-        curried_hook = partial(_sign_request_hook, region, service, holder, False)
+        curried_hook = partial(_sign_request_hook, 'ap-southeast-1', 'execute-api', None, False)
 
         request_body = b'request data'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
@@ -458,56 +438,66 @@ class TestSignRequestHook:
         assert 'x-amz-date' in request.headers
 
     @pytest.mark.asyncio
-    async def test_sign_request_hook_skips_signing_when_skip_auth(self):
+    async def test_sign_request_hook_skips_signing_when_skip_auth(self, mock_create_session):
         """Request is sent unsigned when credentials are unavailable and skip_auth is True."""
-        holder = create_mock_session_holder()
-        holder.get_session.return_value.get_credentials.return_value = None
+        mock_session = create_mock_session()
+        mock_session.get_credentials.return_value = None
+        mock_create_session.return_value = mock_session
 
         request_body = b'{"test": "data"}'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
 
-        await _sign_request_hook('us-east-1', 'execute-api', holder, True, request)
+        await _sign_request_hook('us-east-1', 'execute-api', None, True, request)
 
         assert 'authorization' not in request.headers
         assert 'x-amz-security-token' not in request.headers
         assert request.headers['content-length'] == str(len(request_body))
 
     @pytest.mark.asyncio
-    async def test_sign_request_hook_raises_when_no_credentials_and_no_skip_auth(self):
+    async def test_sign_request_hook_raises_when_no_credentials_and_no_skip_auth(
+        self, mock_create_session
+    ):
         """ValueError is raised when credentials are unavailable and skip_auth is False."""
-        holder = create_mock_session_holder()
-        holder.get_session.return_value.get_credentials.return_value = None
+        mock_session = create_mock_session()
+        mock_session.get_credentials.return_value = None
+        mock_create_session.return_value = mock_session
 
         request_body = b'{"test": "data"}'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
 
         with pytest.raises(ValueError, match='No AWS credentials available'):
-            await _sign_request_hook('us-east-1', 'execute-api', holder, False, request)
+            await _sign_request_hook('us-east-1', 'execute-api', None, False, request)
 
     @pytest.mark.asyncio
-    async def test_sign_request_hook_no_credentials_still_calls_get_session(self):
-        """get_session is called even when credentials end up None."""
-        holder = create_mock_session_holder()
-        holder.get_session.return_value.get_credentials.return_value = None
+    async def test_sign_request_hook_no_credentials_still_creates_session(
+        self, mock_create_session
+    ):
+        """create_aws_session is called even when credentials end up None."""
+        mock_session = create_mock_session()
+        mock_session.get_credentials.return_value = None
+        mock_create_session.return_value = mock_session
 
         request_body = b'test'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
 
         with pytest.raises(ValueError):
-            await _sign_request_hook('us-east-1', 'execute-api', holder, False, request)
+            await _sign_request_hook('us-east-1', 'execute-api', None, False, request)
 
-        holder.get_session.assert_called_once()
+        mock_create_session.assert_called_once()
 
     @pytest.mark.asyncio
     @patch('mcp_proxy_for_aws.sigv4_helper.SigV4HTTPXAuth')
-    async def test_sign_request_hook_no_credentials_does_not_create_auth(self, mock_auth_class):
+    async def test_sign_request_hook_no_credentials_does_not_create_auth(
+        self, mock_auth_class, mock_create_session
+    ):
         """SigV4HTTPXAuth is never instantiated when credentials are None and skip_auth is True."""
-        holder = create_mock_session_holder()
-        holder.get_session.return_value.get_credentials.return_value = None
+        mock_session = create_mock_session()
+        mock_session.get_credentials.return_value = None
+        mock_create_session.return_value = mock_session
 
         request_body = b'test'
         request = httpx.Request('POST', 'https://example.com/mcp', content=request_body)
 
-        await _sign_request_hook('us-east-1', 'execute-api', holder, True, request)
+        await _sign_request_hook('us-east-1', 'execute-api', None, True, request)
 
         mock_auth_class.assert_not_called()

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -22,7 +22,7 @@ from mcp_proxy_for_aws.server import (
     parse_args,
     run_proxy,
 )
-from mcp_proxy_for_aws.sigv4_helper import SessionHolder, create_sigv4_client
+from mcp_proxy_for_aws.sigv4_helper import create_sigv4_client
 from mcp_proxy_for_aws.utils import determine_service_name
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -406,11 +406,7 @@ class TestServer:
     @patch('mcp_proxy_for_aws.sigv4_helper.httpx.AsyncClient')
     def test_create_sigv4_client(self, mock_async_client):
         """Test creating SigV4 authenticated client with request hooks."""
-        session_holder = SessionHolder(profile='test-profile')
-
-        create_sigv4_client(
-            service='test-service', region='us-west-2', session_holder=session_holder
-        )
+        create_sigv4_client(service='test-service', region='us-west-2', profile='test-profile')
 
         assert mock_async_client.call_count == 1
         call_args = mock_async_client.call_args
@@ -421,11 +417,7 @@ class TestServer:
 
     def test_create_sigv4_client_no_credentials(self):
         """Test that credential check happens in sign_request_hook, not during client creation."""
-        session_holder = SessionHolder()
-
-        client = create_sigv4_client(
-            service='test-service', region='test-region', session_holder=session_holder
-        )
+        client = create_sigv4_client(service='test-service', region='test-region')
         assert client is not None
 
     def test_main_module_execution(self):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -406,9 +406,7 @@ class TestServer:
     @patch('mcp_proxy_for_aws.sigv4_helper.httpx.AsyncClient')
     def test_create_sigv4_client(self, mock_async_client):
         """Test creating SigV4 authenticated client with request hooks."""
-        mock_session = Mock()
-        mock_session.get_credentials.return_value = Mock(access_key='test-key')
-        session_holder = SessionHolder(mock_session, profile='test-profile')
+        session_holder = SessionHolder(profile='test-profile')
 
         create_sigv4_client(
             service='test-service', region='us-west-2', session_holder=session_holder
@@ -423,8 +421,7 @@ class TestServer:
 
     def test_create_sigv4_client_no_credentials(self):
         """Test that credential check happens in sign_request_hook, not during client creation."""
-        mock_session = Mock()
-        session_holder = SessionHolder(mock_session)
+        session_holder = SessionHolder()
 
         client = create_sigv4_client(
             service='test-service', region='test-region', session_holder=session_holder

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -15,7 +15,6 @@
 """Unit tests for sigv4_helper module."""
 
 import httpx
-import logging
 import pytest
 from httpx import __version__ as httpx_version
 from mcp.types import Implementation
@@ -117,8 +116,7 @@ class TestCreateSigv4Client:
         """Test creating SigV4 client with default parameters."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        mock_session = Mock()
-        session_holder = SessionHolder(mock_session)
+        session_holder = SessionHolder()
 
         # Test client creation
         result = create_sigv4_client(
@@ -146,7 +144,7 @@ class TestCreateSigv4Client:
         """Test creating SigV4 client with custom headers."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        session_holder = SessionHolder(Mock())
+        session_holder = SessionHolder()
 
         # Test client creation with custom headers
         custom_headers = {'Custom-Header': 'custom-value'}
@@ -173,9 +171,7 @@ class TestCreateSigv4Client:
         mock_client = Mock()
         mock_client_class.return_value = mock_client
 
-        mock_session = Mock()
-        mock_session.get_credentials.return_value = Mock(access_key='test-key')
-        session_holder = SessionHolder(mock_session, profile='test-profile')
+        session_holder = SessionHolder(profile='test-profile')
 
         # Test client creation with custom parameters
         result = create_sigv4_client(
@@ -190,7 +186,7 @@ class TestCreateSigv4Client:
         """Test creating SigV4 client with additional kwargs."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        session_holder = SessionHolder(Mock())
+        session_holder = SessionHolder()
 
         # Test client creation with additional kwargs
         result = create_sigv4_client(
@@ -215,7 +211,7 @@ class TestCreateSigv4Client:
         """Test creating SigV4 client when prompts exist in the system context."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        session_holder = SessionHolder(Mock())
+        session_holder = SessionHolder()
 
         prompt_context_headers = {
             'X-MCP-Prompt-Context': 'enabled',
@@ -256,7 +252,7 @@ class TestCreateSigv4Client:
         """Test that User-Agent omits client info when disable_telemetry is True."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        session_holder = SessionHolder(Mock())
+        session_holder = SessionHolder()
         mock_get_client_info.return_value = Implementation(name='My Client', version='2.0')
 
         result = create_sigv4_client(
@@ -281,7 +277,7 @@ class TestCreateSigv4Client:
         """Test that User-Agent includes client info when disable_telemetry is False."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        session_holder = SessionHolder(Mock())
+        session_holder = SessionHolder()
         mock_get_client_info.return_value = Implementation(name='My Client', version='2.0')
 
         result = create_sigv4_client(
@@ -302,72 +298,42 @@ class TestCreateSigv4Client:
 class TestSessionHolder:
     """Test cases for the SessionHolder class."""
 
-    def test_refresh_if_needed_noop_when_not_marked(self):
-        """refresh_if_needed does nothing when not marked."""
-        mock_session = Mock()
-        holder = SessionHolder(mock_session)
-
-        holder.refresh_if_needed()
-
-        assert holder.session is mock_session
-
     @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
-    def test_refresh_if_needed_creates_new_session_when_marked(self, mock_create):
-        """refresh_if_needed replaces the session after mark_needs_refresh."""
-        old_session = Mock()
+    def test_get_session_creates_fresh_session(self, mock_create):
+        """get_session always creates a fresh boto3 session."""
         new_session = Mock()
         mock_create.return_value = new_session
-        holder = SessionHolder(old_session, profile='my-profile')
+        holder = SessionHolder(profile='my-profile')
 
-        holder.mark_needs_refresh()
-        holder.refresh_if_needed()
+        result = holder.get_session()
 
         mock_create.assert_called_once_with('my-profile')
-        assert holder.session is new_session
+        assert result is new_session
 
     @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
-    def test_refresh_clears_flag_on_success(self, mock_create):
-        """After a successful refresh the flag is cleared — second call is a no-op."""
-        mock_create.return_value = Mock()
-        holder = SessionHolder(Mock())
+    def test_get_session_creates_new_session_each_call(self, mock_create):
+        """Each call to get_session creates a new session (no caching)."""
+        session_a = Mock()
+        session_b = Mock()
+        mock_create.side_effect = [session_a, session_b]
+        holder = SessionHolder(profile='default')
 
-        holder.mark_needs_refresh()
-        holder.refresh_if_needed()
-        mock_create.reset_mock()
+        first = holder.get_session()
+        second = holder.get_session()
 
-        holder.refresh_if_needed()
-        mock_create.assert_not_called()
-
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
-    def test_refresh_keeps_flag_on_failure(self, mock_create):
-        """If refresh fails the flag stays set so the next call retries."""
-        old_session = Mock()
-        mock_create.side_effect = ValueError('no creds')
-        holder = SessionHolder(old_session)
-
-        holder.mark_needs_refresh()
-        holder.refresh_if_needed()
-
-        # Session unchanged
-        assert holder.session is old_session
-        # Flag still set — next call retries
-        mock_create.side_effect = None
-        mock_create.return_value = Mock()
-        holder.refresh_if_needed()
+        assert first is session_a
+        assert second is session_b
         assert mock_create.call_count == 2
 
     @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
-    def test_refresh_logs_original_error_on_failure(self, mock_create, caplog):
-        """Failed refresh logs the original ValueError."""
-        mock_create.side_effect = ValueError('session creation boom')
-        holder = SessionHolder(Mock())
+    def test_get_session_passes_none_profile(self, mock_create):
+        """get_session passes None profile when none was configured."""
+        mock_create.return_value = Mock()
+        holder = SessionHolder()
 
-        holder.mark_needs_refresh()
-        with caplog.at_level(logging.WARNING):
-            holder.refresh_if_needed()
+        holder.get_session()
 
-        assert 'Failed to create fresh AWS session' in caplog.text
-        assert 'session creation boom' in caplog.text
+        mock_create.assert_called_once_with(None)
 
 
 class TestSanitizeHeaders:

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -21,7 +21,6 @@ from mcp.types import Implementation
 from mcp_proxy_for_aws import __version__
 from mcp_proxy_for_aws.sigv4_helper import (
     SENSITIVE_HEADERS,
-    SessionHolder,
     SigV4HTTPXAuth,
     _sanitize_headers,
     create_aws_session,
@@ -116,12 +115,8 @@ class TestCreateSigv4Client:
         """Test creating SigV4 client with default parameters."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        session_holder = SessionHolder()
 
-        # Test client creation
-        result = create_sigv4_client(
-            service='test-service', region='test-region', session_holder=session_holder
-        )
+        result = create_sigv4_client(service='test-service', region='test-region')
 
         # Check that AsyncClient was called with correct parameters
         call_args = mock_client_class.call_args
@@ -144,14 +139,11 @@ class TestCreateSigv4Client:
         """Test creating SigV4 client with custom headers."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        session_holder = SessionHolder()
 
-        # Test client creation with custom headers
         custom_headers = {'Custom-Header': 'custom-value'}
         result = create_sigv4_client(
             service='test-service',
             region='test-region',
-            session_holder=session_holder,
             headers=custom_headers,
         )
 
@@ -171,14 +163,10 @@ class TestCreateSigv4Client:
         mock_client = Mock()
         mock_client_class.return_value = mock_client
 
-        session_holder = SessionHolder(profile='test-profile')
-
-        # Test client creation with custom parameters
         result = create_sigv4_client(
-            service='custom-service', session_holder=session_holder, region='us-east-1'
+            service='custom-service', region='us-east-1', profile='test-profile'
         )
 
-        # Verify client was created
         assert result == mock_client
 
     @patch('httpx.AsyncClient')
@@ -186,13 +174,10 @@ class TestCreateSigv4Client:
         """Test creating SigV4 client with additional kwargs."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        session_holder = SessionHolder()
 
-        # Test client creation with additional kwargs
         result = create_sigv4_client(
             service='test-service',
             region='test-region',
-            session_holder=session_holder,
             verify=False,
             proxies={'http': 'http://proxy:8080'},
         )
@@ -211,7 +196,6 @@ class TestCreateSigv4Client:
         """Test creating SigV4 client when prompts exist in the system context."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        session_holder = SessionHolder()
 
         prompt_context_headers = {
             'X-MCP-Prompt-Context': 'enabled',
@@ -220,7 +204,6 @@ class TestCreateSigv4Client:
 
         result = create_sigv4_client(
             service='test-service',
-            session_holder=session_holder,
             headers=prompt_context_headers,
             region='us-west-2',
         )
@@ -252,13 +235,11 @@ class TestCreateSigv4Client:
         """Test that User-Agent omits client info when disable_telemetry is True."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        session_holder = SessionHolder()
         mock_get_client_info.return_value = Implementation(name='My Client', version='2.0')
 
         result = create_sigv4_client(
             service='test-service',
             region='test-region',
-            session_holder=session_holder,
             disable_telemetry=True,
         )
 
@@ -277,13 +258,11 @@ class TestCreateSigv4Client:
         """Test that User-Agent includes client info when disable_telemetry is False."""
         mock_client = Mock()
         mock_client_class.return_value = mock_client
-        session_holder = SessionHolder()
         mock_get_client_info.return_value = Implementation(name='My Client', version='2.0')
 
         result = create_sigv4_client(
             service='test-service',
             region='test-region',
-            session_holder=session_holder,
             disable_telemetry=False,
         )
 
@@ -293,47 +272,6 @@ class TestCreateSigv4Client:
         assert 'mcp-proxy-for-aws' in user_agent
         assert 'my-client/2.0' in user_agent
         assert result == mock_client
-
-
-class TestSessionHolder:
-    """Test cases for the SessionHolder class."""
-
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
-    def test_get_session_creates_fresh_session(self, mock_create):
-        """get_session always creates a fresh boto3 session."""
-        new_session = Mock()
-        mock_create.return_value = new_session
-        holder = SessionHolder(profile='my-profile')
-
-        result = holder.get_session()
-
-        mock_create.assert_called_once_with('my-profile')
-        assert result is new_session
-
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
-    def test_get_session_creates_new_session_each_call(self, mock_create):
-        """Each call to get_session creates a new session (no caching)."""
-        session_a = Mock()
-        session_b = Mock()
-        mock_create.side_effect = [session_a, session_b]
-        holder = SessionHolder(profile='default')
-
-        first = holder.get_session()
-        second = holder.get_session()
-
-        assert first is session_a
-        assert second is session_b
-        assert mock_create.call_count == 2
-
-    @patch('mcp_proxy_for_aws.sigv4_helper.create_aws_session')
-    def test_get_session_passes_none_profile(self, mock_create):
-        """get_session passes None profile when none was configured."""
-        mock_create.return_value = Mock()
-        holder = SessionHolder()
-
-        holder.get_session()
-
-        mock_create.assert_called_once_with(None)
 
 
 class TestSanitizeHeaders:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -22,7 +22,7 @@ from mcp_proxy_for_aws.utils import (
     determine_service_name,
     validate_endpoint_url,
 )
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 
 class TestValidateEndpointUrl:
@@ -146,8 +146,8 @@ class TestCreateTransportWithSigv4:
 
             mock_create_sigv4_client.assert_called_once_with(
                 service=service,
-                session_holder=ANY,
                 region=region,
+                profile=profile,
                 headers={'test': 'header'},
                 timeout=custom_timeout,
                 auth=None,
@@ -178,8 +178,8 @@ class TestCreateTransportWithSigv4:
 
             mock_create_sigv4_client.assert_called_once_with(
                 service=service,
-                session_holder=ANY,
                 region=region,
+                profile=None,
                 headers=None,
                 timeout=custom_timeout,
                 auth=None,
@@ -210,8 +210,8 @@ class TestCreateTransportWithSigv4:
 
         mock_create_sigv4_client.assert_called_once_with(
             service=service,
-            session_holder=ANY,
             region=region,
+            profile=None,
             headers=None,
             timeout=custom_timeout,
             auth=None,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -115,16 +115,13 @@ class TestValidateEndpointUrl:
 class TestCreateTransportWithSigv4:
     """Test cases for create_transport_with_sigv4 function (line 129)."""
 
-    @patch('mcp_proxy_for_aws.utils.create_aws_session')
     @patch('mcp_proxy_for_aws.utils.create_sigv4_client')
-    def test_create_transport_with_sigv4(self, mock_create_sigv4_client, mock_create_session):
+    def test_create_transport_with_sigv4(self, mock_create_sigv4_client):
         """Test creating StreamableHttpTransport with SigV4 authentication."""
         from httpx import Timeout
 
         mock_client = MagicMock()
         mock_create_sigv4_client.return_value = mock_client
-        mock_session = MagicMock()
-        mock_create_session.return_value = mock_session
 
         url = 'https://test-service.us-west-2.api.aws/mcp'
         service = 'test-service'
@@ -137,15 +134,11 @@ class TestCreateTransportWithSigv4:
             url, service, region, metadata, custom_timeout, profile
         )
 
-        # Verify session was created with profile
-        mock_create_session.assert_called_once_with(profile)
-
         # Verify result is StreamableHttpTransport
         assert isinstance(result, StreamableHttpTransport)
         assert result.url == url
 
         # Test that the httpx_client_factory calls create_sigv4_client correctly
-        # We need to access the factory through the transport's internal structure
         if hasattr(result, 'httpx_client_factory') and result.httpx_client_factory:
             factory = result.httpx_client_factory
             test_kwargs = {'headers': {'test': 'header'}, 'timeout': Timeout(30.0), 'auth': None}
@@ -163,19 +156,12 @@ class TestCreateTransportWithSigv4:
                 skip_auth=False,
             )
         else:
-            # If we can't access the factory directly, just verify the transport was created
             assert result is not None
 
-    @patch('mcp_proxy_for_aws.utils.create_aws_session')
     @patch('mcp_proxy_for_aws.utils.create_sigv4_client')
-    def test_create_transport_with_sigv4_no_profile(
-        self, mock_create_sigv4_client, mock_create_session
-    ):
+    def test_create_transport_with_sigv4_no_profile(self, mock_create_sigv4_client):
         """Test creating transport without profile."""
         from httpx import Timeout
-
-        mock_session = MagicMock()
-        mock_create_session.return_value = mock_session
 
         url = 'https://test-service.us-west-2.api.aws/mcp'
         service = 'test-service'
@@ -185,11 +171,7 @@ class TestCreateTransportWithSigv4:
 
         result = create_transport_with_sigv4(url, service, region, metadata, custom_timeout)
 
-        # Verify session was created without profile
-        mock_create_session.assert_called_once_with(None)
-
         # Test that the httpx_client_factory calls create_sigv4_client correctly
-        # We need to access the factory through the transport's internal structure
         if hasattr(result, 'httpx_client_factory') and result.httpx_client_factory:
             factory = result.httpx_client_factory
             factory(headers=None, timeout=None, auth=None)
@@ -206,19 +188,12 @@ class TestCreateTransportWithSigv4:
                 skip_auth=False,
             )
         else:
-            # If we can't access the factory directly, just verify the transport was created
             assert result is not None
 
-    @patch('mcp_proxy_for_aws.utils.create_aws_session')
     @patch('mcp_proxy_for_aws.utils.create_sigv4_client')
-    def test_create_transport_with_sigv4_kwargs_passthrough(
-        self, mock_create_sigv4_client, mock_create_session
-    ):
+    def test_create_transport_with_sigv4_kwargs_passthrough(self, mock_create_sigv4_client):
         """Test that kwargs are passed through to create_sigv4_client."""
         from httpx import Timeout
-
-        mock_session = MagicMock()
-        mock_create_session.return_value = mock_session
 
         url = 'https://test-service.us-west-2.api.aws/mcp'
         service = 'test-service'


### PR DESCRIPTION
## Summary

### Changes

Remove credential session caching from `SessionHolder` so that every request reads fresh credentials from disk. Previously, the proxy cached a `boto3.Session` and only refreshed it reactively after receiving a 401/403 error. Now, `SessionHolder.get_session()` always creates a new session, ensuring account switches and credential refreshes on disk take effect immediately.

- Replaced `mark_needs_refresh()` / `refresh_if_needed()` with a single `get_session()` method that always returns a fresh session
- Removed reactive 401/403 refresh logic from `_handle_error_response` (no longer needed)
- Simplified `create_transport_with_sigv4` — no longer creates an initial session at startup

### User experience

**Before:** If you switched AWS accounts or refreshed credentials on disk while the proxy was running, the proxy continued using the old cached credentials until they expired and triggered a 401/403. This could result in requests being signed with the wrong account's credentials.

**After:** Every request reads the current credentials from disk. Switching accounts or refreshing credentials takes effect on the very next request — no 401 roundtrip needed.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.