### PR TITLE
bump: version 1.5.0 → 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v1.6.0 (2026-05-29)
+
+### Added
+
+- Per-call AWS profile override middleware for dynamic credential switching (#266)
+
 ### Fixed
 
 - Always read fresh credentials from disk on every request instead of caching and refreshing reactively on auth errors (#294)
+- Prevent credential_process hang on Windows in stdio transport mode (#293)
 
 ## v1.5.0 (2026-05-22)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ members = [
 name = "mcp-proxy-for-aws"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "1.5.0"
+version = "1.6.0"
 
 description = "MCP Proxy for AWS"
 readme = "README.md"


### PR DESCRIPTION
## Summary

### Changes

- Bump version from 1.5.0 to 1.6.0
- Update CHANGELOG.md with v1.6.0 release notes

### User experience

No user-facing UX change. This release includes:
- **Added**: Per-call AWS profile override middleware for dynamic credential switching (#266)
- **Fixed**: Always read fresh credentials from disk on every request (#294)
- **Fixed**: Prevent credential_process hang on Windows in stdio transport mode (#293)

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.