### PR TITLE
feat(client): add metadata parameter to aws_iam_streamablehttp_client

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,24 @@ mcp_client = aws_iam_streamablehttp_client(
 )
 ```
 
+#### Injecting Metadata
+
+You can inject metadata into the MCP `_meta` field on every request using the `metadata` parameter. This is useful for passing additional context to the server that cannot be sent as HTTP headers due to size limits.
+
+```python
+from mcp_proxy_for_aws.client import aws_iam_streamablehttp_client
+
+mcp_client = aws_iam_streamablehttp_client(
+    endpoint=mcp_url,
+    aws_region=region,
+    aws_service=service,
+    metadata={
+        "custom/session-context": "my-value",
+        "custom/tracking-id": "abc-123",
+    },
+)
+```
+
 ### Integration Patterns
 
 The library supports two integration patterns depending on your framework:

--- a/mcp_proxy_for_aws/client.py
+++ b/mcp_proxy_for_aws/client.py
@@ -132,7 +132,9 @@ def aws_iam_streamablehttp_client(
 
     # Append metadata injection hook if metadata is provided
     if metadata:
-        http_client.event_hooks.setdefault('request', []).insert(0, partial(_inject_metadata_hook, metadata))
+        http_client.event_hooks.setdefault('request', []).insert(
+            0, partial(_inject_metadata_hook, metadata)
+        )
         logger.debug('Metadata injection enabled with %d keys', len(metadata))
 
     # Return the streamable HTTP client context manager with AWS IAM authentication

--- a/mcp_proxy_for_aws/client.py
+++ b/mcp_proxy_for_aws/client.py
@@ -19,10 +19,11 @@ from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStre
 from botocore.credentials import Credentials
 from contextlib import _AsyncGeneratorContextManager
 from datetime import timedelta
+from functools import partial
 from mcp.client.streamable_http import GetSessionIdCallback, streamable_http_client
 from mcp.shared._httpx_utils import McpHttpClientFactory, create_mcp_http_client
 from mcp.shared.message import SessionMessage
-from mcp_proxy_for_aws.sigv4_helper import SigV4HTTPXAuth
+from mcp_proxy_for_aws.sigv4_helper import SigV4HTTPXAuth, _inject_metadata_hook
 from mcp_proxy_for_aws.utils import validate_endpoint_url
 from typing import Optional
 
@@ -37,6 +38,7 @@ def aws_iam_streamablehttp_client(
     aws_profile: Optional[str] = None,
     credentials: Optional[Credentials] = None,
     headers: Optional[dict[str, str]] = None,
+    metadata: Optional[dict[str, str]] = None,
     timeout: float | timedelta = 30,
     sse_read_timeout: float | timedelta = 60 * 5,
     terminate_on_close: bool = True,
@@ -62,6 +64,9 @@ def aws_iam_streamablehttp_client(
         aws_profile: The AWS profile to use for authentication.
         credentials: Optional AWS credentials from boto3/botocore. If provided, takes precedence over aws_profile.
         headers: Optional additional HTTP headers to include in requests.
+        metadata: Optional metadata to inject into the MCP _meta field on every request.
+            Useful for passing additional context to the server that cannot be sent as
+            HTTP headers due to size limits.
         timeout: Request timeout in seconds or timedelta object. Defaults to 30 seconds.
         sse_read_timeout: Server-sent events read timeout in seconds or timedelta object.
         terminate_on_close: Whether to terminate the connection on close.
@@ -124,6 +129,11 @@ def aws_iam_streamablehttp_client(
         timeout.total_seconds() if isinstance(timeout, timedelta) else timeout
     )
     http_client = httpx_client_factory(headers=headers, timeout=httpx_timeout, auth=auth)
+
+    # Append metadata injection hook if metadata is provided
+    if metadata:
+        http_client.event_hooks.setdefault('request', []).insert(0, partial(_inject_metadata_hook, metadata))
+        logger.debug('Metadata injection enabled with %d keys', len(metadata))
 
     # Return the streamable HTTP client context manager with AWS IAM authentication
     return streamable_http_client(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -335,3 +335,106 @@ async def test_http_localhost_endpoint_allowed(mock_session, mock_streams):
                 httpx_client_factory=mock_factory,
             ):
                 pass
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'metadata',
+    [
+        {'com.example/tracking-id': 'abc-123'},
+        {'com.example/key1': 'value1', 'com.example/key2': 'value2'},
+        {'traceparent': '00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01'},
+    ],
+    ids=['single-key', 'multiple-keys', 'otel-trace-context'],
+)
+async def test_metadata_adds_event_hook(mock_session, mock_streams, metadata):
+    """Test that providing metadata adds a request event hook to the http client."""
+    mock_read, mock_write, mock_get_session = mock_streams
+
+    with patch('boto3.Session', return_value=mock_session):
+        with patch('mcp_proxy_for_aws.client.streamable_http_client') as mock_stream_client:
+            mock_http_client = Mock()
+            mock_http_client.event_hooks = {'request': []}
+            mock_factory = Mock(return_value=mock_http_client)
+            mock_stream_client.return_value.__aenter__ = AsyncMock(
+                return_value=(mock_read, mock_write, mock_get_session)
+            )
+            mock_stream_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            async with aws_iam_streamablehttp_client(
+                endpoint='https://test.example.com/mcp',
+                aws_service='bedrock-agentcore',
+                metadata=metadata,
+                httpx_client_factory=mock_factory,
+            ):
+                pass
+
+            # Factory should always be used
+            mock_factory.assert_called_once()
+            # Event hook should be added to the client
+            assert len(mock_http_client.event_hooks['request']) == 1
+            assert mock_stream_client.call_args[1]['http_client'] is mock_http_client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'metadata',
+    [None, {}],
+    ids=['none', 'empty-dict'],
+)
+async def test_metadata_falsy_no_hook_added(mock_session, mock_streams, metadata):
+    """Test that falsy metadata (None or empty) does not add event hooks."""
+    mock_read, mock_write, mock_get_session = mock_streams
+    mock_http_client = Mock()
+    mock_http_client.event_hooks = {'request': []}
+    mock_factory = Mock(return_value=mock_http_client)
+
+    with patch('boto3.Session', return_value=mock_session):
+        with patch('mcp_proxy_for_aws.client.streamable_http_client') as mock_stream_client:
+            mock_stream_client.return_value.__aenter__ = AsyncMock(
+                return_value=(mock_read, mock_write, mock_get_session)
+            )
+            mock_stream_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            async with aws_iam_streamablehttp_client(
+                endpoint='https://test.example.com/mcp',
+                aws_service='bedrock-agentcore',
+                metadata=metadata,
+                httpx_client_factory=mock_factory,
+            ):
+                pass
+
+            mock_factory.assert_called_once()
+            assert len(mock_http_client.event_hooks['request']) == 0
+
+
+@pytest.mark.asyncio
+async def test_metadata_preserves_factory_headers_and_auth(mock_session, mock_streams):
+    """Test that headers and SigV4 auth are passed to the factory when metadata is set."""
+    mock_read, mock_write, mock_get_session = mock_streams
+    headers = {'X-Custom-Header': 'test123'}
+
+    with patch('boto3.Session', return_value=mock_session):
+        with patch('mcp_proxy_for_aws.client.SigV4HTTPXAuth') as mock_auth_cls:
+            with patch('mcp_proxy_for_aws.client.streamable_http_client') as mock_stream_client:
+                mock_auth = Mock()
+                mock_auth_cls.return_value = mock_auth
+                mock_http_client = Mock()
+                mock_http_client.event_hooks = {'request': []}
+                mock_factory = Mock(return_value=mock_http_client)
+                mock_stream_client.return_value.__aenter__ = AsyncMock(
+                    return_value=(mock_read, mock_write, mock_get_session)
+                )
+                mock_stream_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+                async with aws_iam_streamablehttp_client(
+                    endpoint='https://test.example.com/mcp',
+                    aws_service='bedrock-agentcore',
+                    metadata={'com.example/key': 'value'},
+                    headers=headers,
+                    httpx_client_factory=mock_factory,
+                ):
+                    pass
+
+                factory_kwargs = mock_factory.call_args[1]
+                assert factory_kwargs['headers'] == headers
+                assert factory_kwargs['auth'] is mock_auth

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -336,6 +336,7 @@ async def test_http_localhost_endpoint_allowed(mock_session, mock_streams):
             ):
                 pass
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     'metadata',


### PR DESCRIPTION
Add optional metadata dict parameter that injects key-value pairs into the MCP _meta field on every request via the existing _inject_metadata_hook. This enables passing additional context to the server that cannot be sent as HTTP headers due to size limits.

Closes #300

## Summary

### Changes

Add an optional `metadata` parameter to `aws_iam_streamablehttp_client` that injects key-value pairs into the MCP `_meta` field on every request,  using the existing `_inject_metadata_hook`.

### User experience

**Before:** Callers who needed to inject `_meta` fields had to wrap the write stream or build custom httpx event hooks manually.
  
  **After:**
  ```python
  async with aws_iam_streamablehttp_client(
      endpoint=url,
      aws_service="my-service",
      aws_region="us-east-1",
      metadata={"com.example/tracking-id": "abc-123"},
  ) as (read, write, get_session_id):
      pass

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?
No - An integration test case for metadata injection already exists in `test_proxy_simple_mcp_server.py`
  - [x] Unit tests pass (229 total, 6 new parametrized metadata tests)
  - [x] Ruff: 0 errors
  - [x] Pyright: 0 errors, 0 warnings

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
