### PR TITLE
Add stale issue/PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,43 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+# Default to no permissions; grant minimally at the job level.
+permissions:
+  actions: none
+  attestations: none
+  checks: none
+  contents: none
+  deployments: none
+  discussions: none
+  id-token: none
+  issues: none
+  models: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          stale-pr-message: "This PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-pr-label: stale
+          stale-issue-label: stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -41,3 +41,4 @@ jobs:
           days-before-issue-close: 14
           stale-pr-label: stale
           stale-issue-label: stale
+          exempt-issue-labels: feature-request,enhancement


### PR DESCRIPTION
## Summary

### Changes

Add a GitHub Actions workflow to automatically mark and close stale issues and PRs. This mirrors the configuration already in use at `aws/agent-toolkit-for-aws`:

- Issues are marked stale after 60 days of inactivity, then closed after 14 more days
- PRs are marked stale after 14 days of inactivity, then closed after 7 more days
- Uses `actions/stale@v10.3.0` with a pinned commit hash

### User experience

Before: Issues and PRs remain open indefinitely regardless of activity.

After: Inactive issues/PRs receive a stale warning comment, then auto-close if no further activity occurs. Any new activity resets the timer.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

Validated workflow syntax. No integration test needed — this is a scheduled GitHub Actions workflow with no impact on application code.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.