### PR TITLE
Pin the version of the MCP Proxy for AWS to respect best security practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ The MCP Proxy serves as a lightweight, client-side bridge between MCP clients (A
 
 ```bash
 # Run the server
-uvx mcp-proxy-for-aws@latest <SigV4 MCP endpoint URL>
+uvx mcp-proxy-for-aws@1.6.0 <SigV4 MCP endpoint URL>
 ```
+
+**Note:** It is recommended to pin to a specific version (e.g., `@1.6.0`) to ensure reproducible behavior. Using `@latest` may pull in breaking changes. Check [PyPI](https://pypi.org/project/mcp-proxy-for-aws/) for the latest stable version.
 
 **Note:** The first run may take tens of seconds as `uvx` downloads and caches dependencies. Subsequent runs will start in seconds. Actual startup time depends on your network and hardware.
 
@@ -162,7 +164,7 @@ AWS_MCP_PROXY_PROFILES="prod-readonly dev staging" mcp-proxy-for-aws https://aws
   "mcpServers": {
     "aws": {
       "command": "uvx",
-      "args": ["mcp-proxy-for-aws@latest", "https://aws-mcp.us-east-1.api.aws/mcp"],
+      "args": ["mcp-proxy-for-aws@1.6.0", "https://aws-mcp.us-east-1.api.aws/mcp"],
       "env": {
         "AWS_MCP_PROXY_PROFILES": "prod-readonly dev staging"
       }
@@ -407,7 +409,7 @@ If your MCP client hangs waiting for a tool call response (e.g., due to an unres
 By default, the proxy signs all outgoing requests with [SigV4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html) using your local AWS credentials. If you need to connect to an MCP endpoint that does not require SigV4 credentials (e.g., a local development server or a publicly accessible endpoint), use the `--skip-auth` flag:
 
 ```bash
-uvx mcp-proxy-for-aws@latest https://my-endpoint.example.com/mcp --skip-auth
+uvx mcp-proxy-for-aws@1.6.0 https://my-endpoint.example.com/mcp --skip-auth
 ```
 
 When `--skip-auth` is set, the proxy sends requests without signing them if AWS credentials are unavailable. If credentials _are_ available, requests are still signed as usual — the flag only changes behavior when credentials cannot be resolved.


### PR DESCRIPTION
## Summary

### Changes

Pin `mcp-proxy-for-aws` to version 1.6.0 across documentation to prevent users from pulling in breaking changes from unreleased versions as well as a security best practice.


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [X] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
