### PR TITLE
chore: release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v1.6.1 (2026-06-12)
+
+### Added
+
+- Metadata parameter to `aws_iam_streamablehttp_client` for passing additional context (#301)
+
+### Fixed
+
+- Pin the version of the MCP Proxy for AWS to respect best security practices (#311)
+
 ## v1.6.0 (2026-05-29)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ members = [
 name = "mcp-proxy-for-aws"
 
 # NOTE: "Patch"=9223372036854775807 bumps next release to zero.
-version = "1.6.0"
+version = "1.6.1"
 
 description = "MCP Proxy for AWS"
 readme = "README.md"


### PR DESCRIPTION
## Summary

### Changes

Bump version to 1.6.1 and update CHANGELOG with changes since v1.6.0:

- **Added**: Metadata parameter to `aws_iam_streamablehttp_client` (#301)
- **Fixed**: Pin the version of the MCP Proxy for AWS to respect best security practices (#311)

### User experience

No user-facing behavior change. This is a version bump release.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.