### PR TITLE
feat(profile): enable per-call aws_profile switching for eks-mcp tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ AWS_MCP_PROXY_PROFILES="prod-readonly dev staging" mcp-proxy-for-aws https://aws
 - Invalid profiles are rejected with an error listing allowed values
 - Each non-default profile gets its own dedicated connection to the backend
 
+This works for both the AWS API MCP server and the EKS MCP server. For example, pointing the
+proxy at the eks-mcp endpoint lets an agent read or manage Kubernetes resources across accounts:
+
+```bash
+mcp-proxy-for-aws https://eks-mcp.us-east-1.api.aws/mcp --profile prod-readonly dev
+```
+
+The agent can then call an eks tool such as `list_k8s_resources` with `aws_profile: "dev"` to
+target the dev account. Pure documentation/guidance tools (e.g. `search_eks_documentation`) make
+no AWS call and so do not expose the `aws_profile` parameter.
+
 **Example MCP config (Kiro):**
 
 ```json

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -83,11 +83,29 @@ class ProfileOverrideMiddleware(Middleware):
 
     # Tools that require AWS authentication and support profile switching
     AUTH_REQUIRING_TOOLS = {
+        # AWS API MCP server
         'aws___call_aws',
         'aws___run_script',
         'aws___get_presigned_url',
         'aws___get_tasks',
         'aws___suggest_aws_commands',
+        # EKS MCP server (tools that call AWS/EKS/Kubernetes; doc/guidance tools omitted)
+        'add_inline_policy',
+        'apply_yaml',
+        'describe_eks_resource',
+        'get_cloudwatch_logs',
+        'get_cloudwatch_metrics',
+        'get_eks_insights',
+        'get_eks_vpc_config',
+        'get_k8s_events',
+        'get_pod_logs',
+        'get_policies_for_role',
+        'list_api_versions',
+        'list_eks_resources',
+        'list_k8s_resources',
+        'manage_eks_stacks',
+        'manage_k8s_resource',
+        'read_k8s_resource',
     }
 
     # ── tool listing ────────────────────────────────────────────────

--- a/tests/unit/test_profile_switcher.py
+++ b/tests/unit/test_profile_switcher.py
@@ -200,6 +200,34 @@ class TestPerCallProfileOverride:
         call_next.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_eks_tool_routes_through_profile_client(self, middleware, mock_context):
+        """An eks-mcp tool with a non-default aws_profile routes through a dedicated client."""
+        mock_client = AsyncMock()
+        mock_call_result = MagicMock()
+        mock_call_result.content = 'result'
+        mock_call_result.structured_content = None
+        mock_call_result.meta = None
+        mock_call_result.is_error = False
+        mock_client.call_tool.return_value = mock_call_result
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'manage_k8s_resource'
+        mock_context.message.arguments = {
+            'cluster_name': 'my-cluster',
+            'aws_profile': 'dev-profile',
+        }
+        call_next = AsyncMock()
+
+        with patch.object(middleware, '_get_profile_client', return_value=mock_client):
+            await middleware.on_call_tool(mock_context, call_next)
+
+        # aws_profile is stripped and the eks tool is forwarded via the dedicated client
+        mock_client.call_tool.assert_called_once_with(
+            'manage_k8s_resource', {'cluster_name': 'my-cluster'}, raise_on_error=False
+        )
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_default_profile_routes_through_call_next(self, middleware, mock_context):
         """When aws_profile matches the default, route through normal path."""
         mock_context.message = Mock()
@@ -373,6 +401,41 @@ class TestFix1OnlyAuthToolsGetInjection:
             )
 
     @pytest.mark.asyncio
+    async def test_all_eks_auth_tools_get_injection(self, middleware, mock_context):
+        """All eks-mcp tools that call AWS/EKS/Kubernetes get aws_profile."""
+        tools = []
+        for name in [
+            'add_inline_policy',
+            'apply_yaml',
+            'describe_eks_resource',
+            'get_cloudwatch_logs',
+            'get_cloudwatch_metrics',
+            'get_eks_insights',
+            'get_eks_vpc_config',
+            'get_k8s_events',
+            'get_pod_logs',
+            'get_policies_for_role',
+            'list_api_versions',
+            'list_eks_resources',
+            'list_k8s_resources',
+            'manage_eks_stacks',
+            'manage_k8s_resource',
+            'read_k8s_resource',
+        ]:
+            tool = Mock()
+            tool.name = name
+            tool.parameters = {'type': 'object', 'properties': {}}
+            tools.append(tool)
+        call_next = AsyncMock(return_value=tools)
+
+        result = await middleware.on_list_tools(mock_context, call_next)
+
+        for tool in result:
+            assert 'aws_profile' in tool.parameters['properties'], (
+                f'{tool.name} should have aws_profile'
+            )
+
+    @pytest.mark.asyncio
     async def test_non_auth_tools_never_get_injection(self, middleware, mock_context):
         """Non-auth tools like search_documentation, list_regions, etc. are untouched."""
         tools = []
@@ -383,6 +446,11 @@ class TestFix1OnlyAuthToolsGetInjection:
             'recommend',
             'retrieve_skill',
             'get_regional_availability',
+            # eks-mcp doc/guidance/manifest-generation tools make no AWS call
+            'search_eks_documentation',
+            'search_eks_troubleshooting_guide',
+            'get_eks_metrics_guidance',
+            'generate_app_manifest',
         ]:
             tool = Mock()
             tool.name = name


### PR DESCRIPTION
## Summary

### Changes

- Enables per-call AWS profile switching for the **eks-mcp** backend by adding its AWS/EKS/Kubernetes tools to `AUTH_REQUIRING_TOOLS` in `ProfileOverrideMiddleware`.

`ProfileOverrideMiddleware` is already service-agnostic — tool listing, invocation, and per-profile routing all gate solely on membership in `AUTH_REQUIRING_TOOLS` and operate on `tool.name`. So the change is just extending that set:
- Added the **16** eks-mcp tools that actually call AWS/EKS/Kubernetes. These arrive as **bare names** (e.g. `manage_k8s_resource`, `apply_yaml`), with no `aws___` gateway prefix, so the bare strings are matched.
- Intentionally **excluded** the 4 pure documentation/guidance/manifest-generation tools (`search_eks_documentation`, `search_eks_troubleshooting_guide`, `get_eks_metrics_guidance`, `generate_app_manifest`) since they make no AWS call — mirroring how the AWS-API allowlist already omits doc/metadata tools like `search_documentation`/`list_regions`.
No routing, prefix, or transport code changes were needed.

## User Experience

The proxy is the documented way to connect to eks-mcp, but per-call profile switching only worked for the AWS API server's tools. Teams managing many EKS clusters across accounts need a single proxy that can target a different account per call (e.g. read pods in `dev` vs `prod`) instead of running one proxy per account.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Workflow syntax validated
- [x] Did integration tests succeed?
- [x] If the feature is a new use case, is it necessary to add a new integration test case?

### Testing details

- Added unit tests: every one of the 16 eks tools gets `aws_profile` injected on `list_tools`; the 4 doc tools do not; and an eks tool called with a non-default `aws_profile` routes through a dedicated per-profile client with the argument stripped.
- `uv run pytest tests/unit/test_profile_switcher.py` — all pass (38).
- `ruff check`, `ruff format --check`, and `pyright` clean.

### Other notes

Closes #322

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.