### PR TITLE
test(server): fix asyncio collection of env-var profile tests

### DIFF
--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -536,20 +536,12 @@ class TestEnvVarProfiles:
 class TestFix2EnvVarPrecedence:
     """Fix #2: AWS_MCP_PROXY_PROFILES takes precedence over AWS_PROFILE."""
 
-    @patch.dict(
-        'os.environ',
-        {
-            'AWS_MCP_PROXY_PROFILES': 'admin dev staging',
-            'AWS_PROFILE': 'some-other-profile',
-        },
-    )
     @patch('mcp_proxy_for_aws.server.AWSMCPProxyClientFactory')
     @patch('mcp_proxy_for_aws.server.create_transport_with_sigv4')
     @patch('mcp_proxy_for_aws.server.FastMCPProxy')
     @patch('mcp_proxy_for_aws.server.determine_aws_region')
     @patch('mcp_proxy_for_aws.server.determine_service_name')
     @patch('mcp_proxy_for_aws.server.add_tool_filtering_middleware')
-    @pytest.mark.asyncio
     async def test_env_var_profiles_wins_over_aws_profile(
         self,
         mock_add_filtering,
@@ -592,7 +584,14 @@ class TestFix2EnvVarPrecedence:
         mock_proxy.add_middleware = Mock()
         mock_fastmcp_proxy.return_value = mock_proxy
 
-        await run_proxy(mock_args)
+        with patch.dict(
+            'os.environ',
+            {
+                'AWS_MCP_PROXY_PROFILES': 'admin dev staging',
+                'AWS_PROFILE': 'some-other-profile',
+            },
+        ):
+            await run_proxy(mock_args)
 
         # Verify the middleware was created with profiles from AWS_MCP_PROXY_PROFILES, not AWS_PROFILE
         middleware_calls = mock_proxy.add_middleware.call_args_list
@@ -609,14 +608,12 @@ class TestFix2EnvVarPrecedence:
 class TestEnvVarActivatesMiddleware:
     """Test that AWS_MCP_PROXY_PROFILES env var activates the profile middleware in run_proxy."""
 
-    @patch.dict('os.environ', {'AWS_MCP_PROXY_PROFILES': 'default dev staging'})
     @patch('mcp_proxy_for_aws.server.AWSMCPProxyClientFactory')
     @patch('mcp_proxy_for_aws.server.create_transport_with_sigv4')
     @patch('mcp_proxy_for_aws.server.FastMCPProxy')
     @patch('mcp_proxy_for_aws.server.determine_aws_region')
     @patch('mcp_proxy_for_aws.server.determine_service_name')
     @patch('mcp_proxy_for_aws.server.add_tool_filtering_middleware')
-    @pytest.mark.asyncio
     async def test_env_var_activates_profile_middleware(
         self,
         mock_add_filtering,
@@ -658,7 +655,8 @@ class TestEnvVarActivatesMiddleware:
         mock_proxy.add_middleware = Mock()
         mock_fastmcp_proxy.return_value = mock_proxy
 
-        await run_proxy(mock_args)
+        with patch.dict('os.environ', {'AWS_MCP_PROXY_PROFILES': 'default dev staging'}):
+            await run_proxy(mock_args)
 
         # Verify middleware was added (add_middleware called for: initialize, tool_error, logging, filtering, profile_override)
         middleware_calls = mock_proxy.add_middleware.call_args_list


### PR DESCRIPTION
## What

Fix two async tests in `tests/unit/test_server.py` that pytest-asyncio was failing to collect.

## Why

`test_env_var_profiles_wins_over_aws_profile` and `test_env_var_activates_profile_middleware` used `@patch.dict('os.environ', ...)` as the **outermost** decorator over an `async def` test. Unlike `@patch`, `patch.dict`'s decorator wrapper is not coroutine-aware, so under `asyncio_mode=auto` the coroutine was never collected and the tests errored with `async def functions are not natively supported` (and `coroutine ... was never awaited`).

## How

Apply the `os.environ` patch as an in-body `with patch.dict(...)` context manager instead of an outer decorator — matching the sibling async tests in the same file that already pass under auto mode. No production code or test assertions change.

## Testing

- Both tests now pass, verified both with and without an ambient `AWS_PROFILE` set in the environment (the tests now fully control their own env).
- `uv run pytest tests/unit/test_server.py` — all pass.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
