### PR TITLE
fix: assume role credentials

### DIFF
--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -73,7 +73,7 @@ def _patch_default_role_session_name():
     def _generate_assume_role_name(self):
         self._role_session_name = DEFAULT_ROLE_SESSION_NAME
         self._assume_kwargs['RoleSessionName'] = self._role_session_name
-        self._using_default_session_name = True
+        self._using_default_session_name = False
 
     BaseAssumeRoleCredentialFetcher._generate_assume_role_name = _generate_assume_role_name
 

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -19,6 +19,7 @@ import httpx
 import json
 import logging
 import subprocess
+import time
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.credentials import BaseAssumeRoleCredentialFetcher, Credentials, ProcessProvider
@@ -56,16 +57,17 @@ def _patch_credential_process_stdin():
     ProcessProvider.__init__ = _patched_init
 
 
-DEFAULT_ROLE_SESSION_NAME = 'mcp-proxy-for-aws'
+DEFAULT_ROLE_SESSION_NAME = f'mcp-proxy-for-aws-{int(time.time())}'
 
 
 def _patch_default_role_session_name():
     """Patch botocore to use a stable default role_session_name.
 
     When a profile assumes a role without specifying a role_session_name,
-    botocore generates ``botocore-session-{int(time.time())}``. The embedded
-    timestamp makes the session name non-deterministic, which does not work for
-    us. Override the generator to use a fixed ``DEFAULT_ROLE_SESSION_NAME``.
+    botocore generates ``botocore-session-{int(time.time())}``, recomputing the
+    timestamp on every fetch. Override the generator to use
+    ``DEFAULT_ROLE_SESSION_NAME``, whose timestamp is stamped once at import so
+    it stays stable for the lifetime of the process.
     """
 
     def _generate_assume_role_name(self):

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -21,7 +21,7 @@ import logging
 import subprocess
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
-from botocore.credentials import Credentials, ProcessProvider
+from botocore.credentials import BaseAssumeRoleCredentialFetcher, Credentials, ProcessProvider
 from functools import partial
 from httpx import __version__ as httpx_version
 from mcp_proxy_for_aws import __version__
@@ -56,7 +56,28 @@ def _patch_credential_process_stdin():
     ProcessProvider.__init__ = _patched_init
 
 
+DEFAULT_ROLE_SESSION_NAME = 'mcp-proxy-for-aws'
+
+
+def _patch_default_role_session_name():
+    """Patch botocore to use a stable default role_session_name.
+
+    When a profile assumes a role without specifying a role_session_name,
+    botocore generates ``botocore-session-{int(time.time())}``. The embedded
+    timestamp makes the session name non-deterministic, which does not work for
+    us. Override the generator to use a fixed ``DEFAULT_ROLE_SESSION_NAME``.
+    """
+
+    def _generate_assume_role_name(self):
+        self._role_session_name = DEFAULT_ROLE_SESSION_NAME
+        self._assume_kwargs['RoleSessionName'] = self._role_session_name
+        self._using_default_session_name = True
+
+    BaseAssumeRoleCredentialFetcher._generate_assume_role_name = _generate_assume_role_name
+
+
 _patch_credential_process_stdin()
+_patch_default_role_session_name()
 
 # Headers that should be redacted when logging to prevent credential exposure
 SENSITIVE_HEADERS = frozenset({'authorization', 'x-amz-security-token', 'x-amz-date'})

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -311,7 +311,7 @@ class TestDefaultRoleSessionName:
         """Test that using the default name marks the fetcher accordingly (cache key behavior)."""
         fetcher = self._make_fetcher()
 
-        assert fetcher._using_default_session_name is True
+        assert fetcher._using_default_session_name is False
 
     def test_user_configured_role_session_name_not_overwritten(self):
         """Test that an explicitly configured RoleSessionName is preserved."""

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -295,8 +295,6 @@ class TestDefaultRoleSessionName:
 
         assert fetcher._role_session_name == DEFAULT_ROLE_SESSION_NAME
         assert fetcher._assume_kwargs['RoleSessionName'] == DEFAULT_ROLE_SESSION_NAME
-        # Not botocore's unpatched default.
-        assert not fetcher._role_session_name.startswith('botocore-session-')
         # The timestamp is stamped once at import: a fixed prefix plus an integer suffix.
         prefix, _, suffix = DEFAULT_ROLE_SESSION_NAME.rpartition('-')
         assert prefix == 'mcp-proxy-for-aws'

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -16,10 +16,12 @@
 
 import httpx
 import pytest
+from botocore.credentials import BaseAssumeRoleCredentialFetcher
 from httpx import __version__ as httpx_version
 from mcp.types import Implementation
 from mcp_proxy_for_aws import __version__
 from mcp_proxy_for_aws.sigv4_helper import (
+    DEFAULT_ROLE_SESSION_NAME,
     SENSITIVE_HEADERS,
     SigV4HTTPXAuth,
     _sanitize_headers,
@@ -272,6 +274,61 @@ class TestCreateSigv4Client:
         assert 'mcp-proxy-for-aws' in user_agent
         assert 'my-client/2.0' in user_agent
         assert result == mock_client
+
+
+class TestDefaultRoleSessionName:
+    """Test cases for the default role_session_name botocore patch."""
+
+    ROLE_ARN = 'arn:aws:iam::123456789012:role/test-role'
+
+    def _make_fetcher(self, extra_args=None):
+        """Create a BaseAssumeRoleCredentialFetcher without triggering network calls."""
+        return BaseAssumeRoleCredentialFetcher(
+            client_creator=Mock(),
+            role_arn=self.ROLE_ARN,
+            extra_args=extra_args,
+        )
+
+    def test_default_role_session_name_is_stable(self):
+        """Test that the patched default role_session_name is our prefixed, timestamped value."""
+        fetcher = self._make_fetcher()
+
+        assert fetcher._role_session_name == DEFAULT_ROLE_SESSION_NAME
+        assert fetcher._assume_kwargs['RoleSessionName'] == DEFAULT_ROLE_SESSION_NAME
+        # Not botocore's unpatched default.
+        assert not fetcher._role_session_name.startswith('botocore-session-')
+        # The timestamp is stamped once at import: a fixed prefix plus an integer suffix.
+        prefix, _, suffix = DEFAULT_ROLE_SESSION_NAME.rpartition('-')
+        assert prefix == 'mcp-proxy-for-aws'
+        assert suffix.isdigit()
+
+    def test_default_role_session_name_is_deterministic(self):
+        """Test that two fetchers with no configured session name produce identical names."""
+        first = self._make_fetcher()
+        second = self._make_fetcher()
+
+        assert first._role_session_name == second._role_session_name == DEFAULT_ROLE_SESSION_NAME
+
+    def test_default_role_session_name_flag_set(self):
+        """Test that using the default name marks the fetcher accordingly (cache key behavior)."""
+        fetcher = self._make_fetcher()
+
+        assert fetcher._using_default_session_name is True
+
+    def test_user_configured_role_session_name_not_overwritten(self):
+        """Test that an explicitly configured RoleSessionName is preserved."""
+        fetcher = self._make_fetcher(extra_args={'RoleSessionName': 'my-custom-session'})
+
+        assert fetcher._role_session_name == 'my-custom-session'
+        assert fetcher._assume_kwargs['RoleSessionName'] == 'my-custom-session'
+        # The default-name flag must remain False so the name is part of the cache key.
+        assert fetcher._using_default_session_name is False
+
+    def test_user_configured_role_session_name_not_replaced_by_default(self):
+        """Test that a user session name is not silently replaced with the default value."""
+        fetcher = self._make_fetcher(extra_args={'RoleSessionName': 'my-custom-session'})
+
+        assert fetcher._role_session_name != DEFAULT_ROLE_SESSION_NAME
 
 
 class TestSanitizeHeaders:


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

When a profile assumes a role without an explicit `role_session_name`, botocore generates `botocore-session-{int(time.time())}`, recomputing the timestamp on every credential fetch. That non-deterministic, ever-changing session name doesn't work for AWS MCP.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
