### PR TITLE
feat: add pip-audit CVE scanning to CI and release workflows

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,31 @@
+name: pip-audit
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions: {}
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Run pip-audit
+        run: uv tool run pip-audit --require-hashes --no-deps -r <(uv export --frozen --no-dev)

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -28,4 +28,4 @@ jobs:
         run: uv sync --frozen --all-extras
 
       - name: Run pip-audit
-        run: uv tool run pip-audit --require-hashes --no-deps -r <(uv export --frozen --no-dev)
+        run: uv tool run pip-audit --require-hashes --no-deps -r <(uv export --frozen --no-dev --no-emit-project)

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -3,8 +3,10 @@ name: pip-audit
 on:
   push:
     branches: ["main"]
+    paths: ["uv.lock"]
   pull_request:
     branches: ["main"]
+    paths: ["uv.lock"]
 
 permissions: {}
 

--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -28,8 +28,32 @@ jobs:
       ref: ${{ github.event.release.target_commitish }}
     secrets: inherit
 
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Run pip-audit
+        run: uv tool run pip-audit --require-hashes --no-deps -r <(uv export --frozen --no-dev)
+
   build:
-    needs: [call-test, call-integ-tests]
+    needs: [call-test, call-integ-tests, audit]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -50,7 +50,7 @@ jobs:
         run: uv sync --frozen --all-extras
 
       - name: Run pip-audit
-        run: uv tool run pip-audit --require-hashes --no-deps -r <(uv export --frozen --no-dev)
+        run: uv tool run pip-audit --require-hashes --no-deps -r <(uv export --frozen --no-dev --no-emit-project)
 
   build:
     needs: [call-test, call-integ-tests, audit]


### PR DESCRIPTION
## Summary

### Changes

- Adds a new `pip-audit.yml` workflow that runs on pushes to main and PRs, scanning locked production dependencies against the OSV vulnerability database
- Adds an `audit` job to the release workflow (`pypi-publish-on-release.yml`) that must pass before the build proceeds
- Uses `uv export --frozen --no-dev` piped into `pip-audit --require-hashes --no-deps` to validate exact locked versions

### User experience

No user-facing change. Builds will now fail if production dependencies contain known critical/high CVEs, preventing vulnerable releases from shipping.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Workflow syntax validated
- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.