### PR TITLE
fix: set user agent on every request explicitly

### DIFF
--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -97,6 +97,30 @@ def _sanitize_headers(headers: Dict[str, str]) -> Dict[str, str]:
     return {k: '[REDACTED]' if k.lower() in SENSITIVE_HEADERS else v for k, v in headers.items()}
 
 
+def _build_user_agent(disable_telemetry: bool) -> str:
+    """Build the User-Agent header value, including client telemetry when available.
+
+    The client's ``Implementation`` (name/version) is only known after the MCP
+    ``initialize`` handshake captures it via ``set_client_info``. This reads
+    ``get_client_info()`` at call time so callers can recompute the value per
+    request instead of freezing it when the HTTP client is constructed.
+
+    Args:
+        disable_telemetry: When True, omit the client info from the User-Agent.
+
+    Returns:
+        The User-Agent string.
+    """
+    user_agent = f'python-httpx/{httpx_version} mcp-proxy-for-aws/{__version__}'
+
+    client_info = get_client_info()
+    if client_info and not disable_telemetry:
+        client_name = client_info.name.lower().replace(' ', '-').replace('/', '-')
+        user_agent += f' {client_name}/{client_info.version}'
+
+    return user_agent
+
+
 class SigV4HTTPXAuth(httpx.Auth):
     """HTTPX Auth class that signs requests with AWS SigV4."""
 
@@ -197,12 +221,11 @@ def create_sigv4_client(
         **kwargs,
     }
 
-    user_agent = f'python-httpx/{httpx_version} mcp-proxy-for-aws/{__version__}'
-
-    client_info = get_client_info()
-    if client_info and not disable_telemetry:
-        client_name = client_info.name.lower().replace(' ', '-').replace('/', '-')
-        user_agent += f' {client_name}/{client_info.version}'
+    # Build an initial User-Agent. The client info captured during the MCP
+    # initialize handshake may not be available yet (the backend connection can
+    # be established before set_client_info runs), so the value is recomputed
+    # per request by _set_user_agent_hook below.
+    user_agent = _build_user_agent(disable_telemetry)
 
     # Add headers if provided
     default_headers = {
@@ -224,11 +247,29 @@ def create_sigv4_client(
         event_hooks={
             'response': [_handle_error_response],
             'request': [
+                partial(_set_user_agent_hook, disable_telemetry),
                 partial(_inject_metadata_hook, metadata or {}),
                 partial(_sign_request_hook, region, service, profile, skip_auth),
             ],
         },
     )
+
+
+async def _set_user_agent_hook(disable_telemetry: bool, request: httpx.Request) -> None:
+    """Request hook to set the User-Agent header with up-to-date client telemetry.
+
+    The HTTP client may be constructed before the MCP initialize handshake
+    captures the client info, so the User-Agent baked in at construction time
+    can be missing the client name/version. Recompute it on every request so the
+    captured client info is reflected once available. SigV4 does not sign the
+    User-Agent header (it is in botocore's blacklist), so updating it here does
+    not affect request signing.
+
+    Args:
+        disable_telemetry: Whether to omit client info from the User-Agent.
+        request: The HTTP request object (modified in-place).
+    """
+    request.headers['User-Agent'] = _build_user_agent(disable_telemetry)
 
 
 async def _handle_error_response(response: httpx.Response) -> None:

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -98,19 +98,7 @@ def _sanitize_headers(headers: Dict[str, str]) -> Dict[str, str]:
 
 
 def _build_user_agent(disable_telemetry: bool) -> str:
-    """Build the User-Agent header value, including client telemetry when available.
-
-    The client's ``Implementation`` (name/version) is only known after the MCP
-    ``initialize`` handshake captures it via ``set_client_info``. This reads
-    ``get_client_info()`` at call time so callers can recompute the value per
-    request instead of freezing it when the HTTP client is constructed.
-
-    Args:
-        disable_telemetry: When True, omit the client info from the User-Agent.
-
-    Returns:
-        The User-Agent string.
-    """
+    """Build the User-Agent header value, including client telemetry when available."""
     user_agent = f'python-httpx/{httpx_version} mcp-proxy-for-aws/{__version__}'
 
     client_info = get_client_info()
@@ -221,10 +209,6 @@ def create_sigv4_client(
         **kwargs,
     }
 
-    # Build an initial User-Agent. The client info captured during the MCP
-    # initialize handshake may not be available yet (the backend connection can
-    # be established before set_client_info runs), so the value is recomputed
-    # per request by _set_user_agent_hook below.
     user_agent = _build_user_agent(disable_telemetry)
 
     # Add headers if provided
@@ -256,19 +240,7 @@ def create_sigv4_client(
 
 
 async def _set_user_agent_hook(disable_telemetry: bool, request: httpx.Request) -> None:
-    """Request hook to set the User-Agent header with up-to-date client telemetry.
-
-    The HTTP client may be constructed before the MCP initialize handshake
-    captures the client info, so the User-Agent baked in at construction time
-    can be missing the client name/version. Recompute it on every request so the
-    captured client info is reflected once available. SigV4 does not sign the
-    User-Agent header (it is in botocore's blacklist), so updating it here does
-    not affect request signing.
-
-    Args:
-        disable_telemetry: Whether to omit client info from the User-Agent.
-        request: The HTTP request object (modified in-place).
-    """
+    """Request hook to set the User-Agent header with up-to-date client telemetry."""
     request.headers['User-Agent'] = _build_user_agent(disable_telemetry)
 
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -418,7 +418,8 @@ class TestServer:
         assert 'event_hooks' in call_args[1]
         assert 'request' in call_args[1]['event_hooks']
         assert 'response' in call_args[1]['event_hooks']
-        assert len(call_args[1]['event_hooks']['request']) == 2
+        # user-agent + metadata + sign hooks
+        assert len(call_args[1]['event_hooks']['request']) == 3
 
     def test_create_sigv4_client_no_credentials(self):
         """Test that credential check happens in sign_request_hook, not during client creation."""

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -25,6 +25,7 @@ from mcp_proxy_for_aws.sigv4_helper import (
     SENSITIVE_HEADERS,
     SigV4HTTPXAuth,
     _sanitize_headers,
+    _set_user_agent_hook,
     create_aws_session,
     create_sigv4_client,
 )
@@ -127,7 +128,8 @@ class TestCreateSigv4Client:
         assert 'response' in call_args[1]['event_hooks']
         assert 'request' in call_args[1]['event_hooks']
         assert len(call_args[1]['event_hooks']['response']) == 1
-        assert len(call_args[1]['event_hooks']['request']) == 2  # metadata + sign hooks
+        # user-agent + metadata + sign hooks
+        assert len(call_args[1]['event_hooks']['request']) == 3
         assert call_args[1]['headers']['Accept'] == 'application/json, text/event-stream'
         expected_user_agent = f'python-httpx/{httpx_version} mcp-proxy-for-aws/{__version__}'
         assert call_args[1]['headers']['User-Agent'] == expected_user_agent
@@ -274,6 +276,95 @@ class TestCreateSigv4Client:
         assert 'mcp-proxy-for-aws' in user_agent
         assert 'my-client/2.0' in user_agent
         assert result == mock_client
+
+    @patch('mcp_proxy_for_aws.sigv4_helper.get_client_info', return_value=None)
+    @patch('httpx.AsyncClient')
+    def test_create_sigv4_client_registers_user_agent_request_hook(
+        self, mock_client_class, mock_get_client_info
+    ):
+        """The first request hook recomputes the User-Agent per request."""
+        mock_client_class.return_value = Mock()
+
+        create_sigv4_client(service='test-service', region='test-region')
+
+        request_hooks = mock_client_class.call_args[1]['event_hooks']['request']
+        # The user-agent hook must run first so a later-captured client info is
+        # reflected on every request, including the signed one.
+        assert request_hooks[0].func is _set_user_agent_hook
+
+
+class TestSetUserAgentHook:
+    """Test cases for the per-request User-Agent hook."""
+
+    @pytest.mark.asyncio
+    @patch('mcp_proxy_for_aws.sigv4_helper.get_client_info', return_value=None)
+    async def test_set_user_agent_hook_without_client_info(self, mock_get_client_info):
+        """Hook sets the base User-Agent when no client info is available."""
+        request = httpx.Request('POST', 'https://example.com/mcp')
+
+        await _set_user_agent_hook(False, request)
+
+        expected = f'python-httpx/{httpx_version} mcp-proxy-for-aws/{__version__}'
+        assert request.headers['User-Agent'] == expected
+
+    @pytest.mark.asyncio
+    @patch('mcp_proxy_for_aws.sigv4_helper.get_client_info')
+    @patch('httpx.AsyncClient')
+    async def test_request_hook_reflects_client_info_set_after_construction(
+        self, mock_client_class, mock_get_client_info
+    ):
+        """Regression: client info captured after construction reaches the User-Agent.
+
+        This is the core of the bug: the backend HTTP client is created (during
+        the proxy's initialize) before set_client_info runs, so a value baked in
+        at construction time would never include the client info. The per-request
+        hook reads get_client_info() at request time, so it picks it up.
+        """
+        mock_client_class.return_value = Mock()
+
+        # Client built before the initialize handshake captures client info.
+        mock_get_client_info.return_value = None
+        create_sigv4_client(service='test-service', region='test-region')
+
+        # Grab the actual user-agent hook registered on the client.
+        user_agent_hook = mock_client_class.call_args[1]['event_hooks']['request'][0]
+
+        # The User-Agent baked in at construction time has no client info.
+        assert 'my-client' not in mock_client_class.call_args[1]['headers']['User-Agent']
+
+        # Client info becomes available later (after initialize handshake).
+        mock_get_client_info.return_value = Implementation(name='My Client', version='2.0')
+        request = httpx.Request('POST', 'https://example.com/mcp')
+        await user_agent_hook(request)
+
+        assert request.headers['User-Agent'].endswith('my-client/2.0')
+
+    @pytest.mark.asyncio
+    @patch('mcp_proxy_for_aws.sigv4_helper.get_client_info')
+    async def test_set_user_agent_hook_respects_disable_telemetry(self, mock_get_client_info):
+        """Hook omits client info when telemetry is disabled."""
+        mock_get_client_info.return_value = Implementation(name='My Client', version='2.0')
+        request = httpx.Request('POST', 'https://example.com/mcp')
+
+        await _set_user_agent_hook(True, request)
+
+        assert 'my-client' not in request.headers['User-Agent']
+
+    @pytest.mark.asyncio
+    @patch('mcp_proxy_for_aws.sigv4_helper.get_client_info')
+    async def test_set_user_agent_hook_overwrites_stale_value(self, mock_get_client_info):
+        """Hook overwrites a User-Agent already present on the request."""
+        mock_get_client_info.return_value = Implementation(name='My Client', version='2.0')
+        request = httpx.Request(
+            'POST',
+            'https://example.com/mcp',
+            headers={'User-Agent': 'stale/0.0'},
+        )
+
+        await _set_user_agent_hook(False, request)
+
+        assert 'stale' not in request.headers['User-Agent']
+        assert request.headers['User-Agent'].endswith('my-client/2.0')
 
 
 class TestDefaultRoleSessionName:


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

Client telemetry (name/version captured during MCP `initialize`) never reached the backend's `User-Agent` header. The `User-Agent` was computed once when the httpx client was built, but FastMCP 3.4.x's `ProxyInitializeMiddleware` connects the backend *before* our `InitializeMiddleware` runs `set_client_info()` — so it was always `None` at build time, and the cached client was reused for the process lifetime. Regressed in 1.6.1 (FastMCP 3.3.1 → 3.4.2); no code change on our side.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
