### PR TITLE
docs: clarify local vs signing region resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ export AWS_MCP_PROXY_PROFILES="prod-readonly dev staging"
 
 > **Note:** `AWS_MCP_PROXY_PROFILES` takes precedence over `--profile` / `AWS_PROFILE` when set.
 
-> **Note:** When getting a `NoRegionError` (surfaced by MCP clients as `-32602: Invalid request parameters`) and using `aws login` profiles, please set `AWS_REGION`.
+> **Note:** When getting a `NoRegionError` (surfaced by MCP clients as `-32602: Invalid request parameters`) and using `aws login` profiles, please configure the region for the given profile using `aws configure set region <region>` or set `AWS_REGION`.
 
 ### Multi-account access
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ export AWS_MCP_PROXY_PROFILES="prod-readonly dev staging"
 
 > **Note:** `AWS_MCP_PROXY_PROFILES` takes precedence over `--profile` / `AWS_PROFILE` when set.
 
+> **Note:** When getting a `NoRegionError` (surfaced by MCP clients as `-32602: Invalid request parameters`) and using `aws login` profiles, please set `AWS_REGION`.
+
 ### Multi-account access
 
 The proxy supports per-call AWS profile switching, allowing agents to work across multiple accounts without restarting.

--- a/README.md
+++ b/README.md
@@ -133,9 +133,11 @@ export AWS_REGION=<aws_region>
 export AWS_MCP_PROXY_PROFILES="prod-readonly dev staging"
 ```
 
-> **Note:** `AWS_MCP_PROXY_PROFILES` takes precedence over `--profile` / `AWS_PROFILE` when set.
+> [!NOTE]
+> `AWS_MCP_PROXY_PROFILES` takes precedence over `--profile` / `AWS_PROFILE` when set.
 
-> **Note:** When getting a `NoRegionError` (surfaced by MCP clients as `-32602: Invalid request parameters`) and using `aws login` profiles, please configure the region for the given profile using `aws configure set region <region>` or set `AWS_REGION`.
+> [!NOTE]
+> When getting a `NoRegionError` (surfaced by MCP clients as `-32602: Invalid request parameters`) and using `aws login` profiles, please configure the region for the given profile using `aws configure set region <region>` or set `AWS_REGION`.
 
 ### Multi-account access
 


### PR DESCRIPTION
## Summary

- Adds a callout under the env-vars section explaining that `--region` / endpoint URL / `--metadata AWS_REGION=...` set the **signing** region for the remote MCP server, while the proxy's local `boto3` session resolves its own region from the standard provider chain for credential refresh.
- Tells users hitting `NoRegionError` at startup (commonly displayed as `-32602: Invalid request parameters` by MCP clients) — typical of AWS CLI v2 `aws login` profiles with no persisted `region = ...` line — to set `AWS_REGION` in the MCP server's environment block.

Refs aws/agent-toolkit-for-aws#63.

## Test plan

- [ ] Render README and confirm the new blockquote sits between the `AWS_MCP_PROXY_PROFILES` note and the **Multi-account access** heading.