### PR TITLE
fix: enforce read-only mode on tools/call requests

### DIFF
--- a/mcp_proxy_for_aws/middleware/tool_filter.py
+++ b/mcp_proxy_for_aws/middleware/tool_filter.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import logging
+import mcp.types as mt
 from collections.abc import Awaitable, Callable
-from fastmcp.server.middleware import Middleware, MiddlewareContext
-from fastmcp.tools import Tool
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools import Tool, ToolResult
 from typing import Sequence
 
 
@@ -26,6 +28,7 @@ class ToolFilteringMiddleware(Middleware):
         """Initialize the middleware."""
         self.read_only = read_only
         self.logger = logger or logging.getLogger(__name__)
+        self._allowed_tools: set[str] | None = None
 
     async def on_list_tools(
         self,
@@ -55,4 +58,20 @@ class ToolFilteringMiddleware(Middleware):
 
             filtered_tools.append(tool)
 
+        self._allowed_tools = {tool.name for tool in filtered_tools}
         return filtered_tools
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        """Reject calls to tools that are not allowed in read-only mode."""
+        if not self.read_only:
+            return await call_next(context)
+
+        tool_name = context.message.name
+        if self._allowed_tools is not None and tool_name not in self._allowed_tools:
+            raise ToolError(f'Tool {tool_name!r} is not available in read-only mode.')
+
+        return await call_next(context)

--- a/mcp_proxy_for_aws/middleware/tool_filter.py
+++ b/mcp_proxy_for_aws/middleware/tool_filter.py
@@ -28,7 +28,6 @@ class ToolFilteringMiddleware(Middleware):
         """Initialize the middleware."""
         self.read_only = read_only
         self.logger = logger or logging.getLogger(__name__)
-        self._allowed_tools: set[str] | None = None
 
     async def on_list_tools(
         self,
@@ -58,7 +57,6 @@ class ToolFilteringMiddleware(Middleware):
 
             filtered_tools.append(tool)
 
-        self._allowed_tools = {tool.name for tool in filtered_tools}
         return filtered_tools
 
     async def on_call_tool(
@@ -70,8 +68,11 @@ class ToolFilteringMiddleware(Middleware):
         if not self.read_only:
             return await call_next(context)
 
-        tool_name = context.message.name
-        if self._allowed_tools is not None and tool_name not in self._allowed_tools:
-            raise ToolError(f'Tool {tool_name!r} is not available in read-only mode.')
+        if context.fastmcp_context:
+            tool = await context.fastmcp_context.fastmcp.get_tool(context.message.name)
+            if not tool or not getattr(tool.annotations, 'readOnlyHint', False):
+                raise ToolError(
+                    f'Tool {context.message.name!r} is not available in read-only mode.'
+                )
 
         return await call_next(context)

--- a/tests/unit/test_tool_filter.py
+++ b/tests/unit/test_tool_filter.py
@@ -15,6 +15,7 @@
 """Tests for the tool filtering middleware."""
 
 import pytest
+from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import MiddlewareContext
 from mcp_proxy_for_aws.middleware.tool_filter import ToolFilteringMiddleware
 from unittest.mock import AsyncMock, Mock
@@ -268,3 +269,133 @@ class TestOnListTools:
         else:
             # All tools should pass
             assert result == tools
+
+
+class TestOnCallTool:
+    """Tests for the on_call_tool method."""
+
+    @pytest.fixture
+    def mock_read_only_tool(self):
+        """Tool with readOnlyHint=True."""
+        tool = Mock()
+        tool.name = 'read_only_tool'
+        tool.annotations = Mock()
+        tool.annotations.readOnlyHint = True
+        return tool
+
+    @pytest.fixture
+    def mock_write_tool(self):
+        """Tool with readOnlyHint=False."""
+        tool = Mock()
+        tool.name = 'write_tool'
+        tool.annotations = Mock()
+        tool.annotations.readOnlyHint = False
+        return tool
+
+    def _make_context(self, tool_name, get_tool_return):
+        """Create a mock MiddlewareContext for on_call_tool."""
+        context = Mock(spec=MiddlewareContext)
+        context.message = Mock()
+        context.message.name = tool_name
+        context.fastmcp_context = Mock()
+        context.fastmcp_context.fastmcp = Mock()
+        context.fastmcp_context.fastmcp.get_tool = AsyncMock(return_value=get_tool_return)
+        return context
+
+    @pytest.mark.asyncio
+    async def test_read_only_false_allows_all_calls(self, mock_write_tool):
+        """Test that read_only=False passes through all tool calls."""
+        # Arrange
+        context = self._make_context('write_tool', mock_write_tool)
+        call_next = AsyncMock(return_value=['result'])
+        middleware = ToolFilteringMiddleware(read_only=False)
+
+        # Act
+        result = await middleware.on_call_tool(context, call_next)
+
+        # Assert
+        assert result == ['result']
+        call_next.assert_called_once_with(context)
+
+    @pytest.mark.asyncio
+    async def test_read_only_true_allows_read_only_tool(self, mock_read_only_tool):
+        """Test that read_only=True allows tools with readOnlyHint=True."""
+        # Arrange
+        context = self._make_context('read_only_tool', mock_read_only_tool)
+        call_next = AsyncMock(return_value=['result'])
+        middleware = ToolFilteringMiddleware(read_only=True)
+
+        # Act
+        result = await middleware.on_call_tool(context, call_next)
+
+        # Assert
+        assert result == ['result']
+        call_next.assert_called_once_with(context)
+
+    @pytest.mark.asyncio
+    async def test_read_only_true_rejects_write_tool(self, mock_write_tool):
+        """Test that read_only=True rejects tools with readOnlyHint=False."""
+        # Arrange
+        context = self._make_context('write_tool', mock_write_tool)
+        call_next = AsyncMock()
+        middleware = ToolFilteringMiddleware(read_only=True)
+
+        # Act & Assert
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(context, call_next)
+
+        assert 'write_tool' in str(exc_info.value)
+        assert 'not available in read-only mode' in str(exc_info.value)
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_read_only_true_rejects_unknown_tool(self):
+        """Test that read_only=True rejects tools that don't exist."""
+        # Arrange
+        context = self._make_context('unknown_tool', None)
+        call_next = AsyncMock()
+        middleware = ToolFilteringMiddleware(read_only=True)
+
+        # Act & Assert
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(context, call_next)
+
+        assert 'unknown_tool' in str(exc_info.value)
+        assert 'not available in read-only mode' in str(exc_info.value)
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_read_only_true_rejects_tool_without_annotations(self):
+        """Test that read_only=True rejects tools with no annotations."""
+        # Arrange
+        tool = Mock()
+        tool.name = 'no_annotations_tool'
+        tool.annotations = None
+        context = self._make_context('no_annotations_tool', tool)
+        call_next = AsyncMock()
+        middleware = ToolFilteringMiddleware(read_only=True)
+
+        # Act & Assert
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(context, call_next)
+
+        assert 'no_annotations_tool' in str(exc_info.value)
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_read_only_true_no_fastmcp_context_passes_through(self):
+        """Test that when fastmcp_context is None, call passes through."""
+        # Arrange
+        context = Mock(spec=MiddlewareContext)
+        context.message = Mock()
+        context.message.name = 'some_tool'
+        context.fastmcp_context = None
+        call_next = AsyncMock(return_value=['result'])
+        middleware = ToolFilteringMiddleware(read_only=True)
+
+        # Act
+        result = await middleware.on_call_tool(context, call_next)
+
+        # Assert
+        assert result == ['result']
+        call_next.assert_called_once_with(context)


### PR DESCRIPTION
## Summary

### Changes

The `--read-only` flag previously only filtered tools from `tools/list` responses. A client that knew the tool name could still invoke it directly via `tools/call`. This adds an `on_call_tool` hook to `ToolFilteringMiddleware` that rejects calls to tools not in the allowed set when `--read-only` is active.

### User experience

**Before:** A client could bypass `--read-only` by directly calling a write tool by name (e.g. `aws___call_aws`), even though it was hidden from `tools/list`.

**After:** Any `tools/call` request targeting a tool that was filtered out in read-only mode is rejected with a `ToolError`.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

Tested manually by piping JSON-RPC messages over stdio with `--read-only` and confirming that `tools/call` to a write tool is now rejected.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.