### PR TITLE
fix: pass resolved region into boto session

### DIFF
--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -154,11 +154,12 @@ class SigV4HTTPXAuth(httpx.Auth):
         yield request
 
 
-def create_aws_session(profile: Optional[str] = None) -> boto3.Session:
-    """Create an AWS session with optional profile.
+def create_aws_session(profile: Optional[str] = None, region: Optional[str] = None) -> boto3.Session:
+    """Create an AWS session with optional profile and region.
 
     Args:
         profile: AWS profile to use (optional)
+        region: AWS region to bind to the boto session (optional)
 
     Returns:
         boto3.Session instance
@@ -167,7 +168,12 @@ def create_aws_session(profile: Optional[str] = None) -> boto3.Session:
         ValueError: If session creation fails
     """
     try:
-        session = boto3.Session(profile_name=profile) if profile else boto3.Session()
+        session_kwargs: Dict[str, Any] = {}
+        if profile:
+            session_kwargs['profile_name'] = profile
+        if region:
+            session_kwargs['region_name'] = region
+        session = boto3.Session(**session_kwargs)
     except Exception as e:
         raise ValueError(f"Failed to create AWS session with profile '{profile}': {e}")
 
@@ -316,7 +322,7 @@ async def _sign_request_hook(
 
     # Always read fresh credentials from disk so account switches
     # and credential refreshes take effect immediately.
-    session = create_aws_session(profile)
+    session = create_aws_session(profile, region)
     credentials = session.get_credentials()
 
     if credentials is None:

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -379,7 +379,7 @@ class TestSignRequestHook:
 
         await _sign_request_hook('us-east-1', 'execute-api', 'my-profile', False, request)
 
-        mock_create_session.assert_called_once_with('my-profile')
+        mock_create_session.assert_called_once_with('my-profile', 'us-east-1')
 
     @pytest.mark.asyncio
     async def test_sign_request_hook_signs_request(self, mock_create_session):
@@ -406,7 +406,7 @@ class TestSignRequestHook:
 
         await _sign_request_hook('us-west-2', 'execute-api', 'test-profile', False, request)
 
-        mock_create_session.assert_called_once_with('test-profile')
+        mock_create_session.assert_called_once_with('test-profile', 'us-west-2')
         assert 'authorization' in request.headers
         assert 'x-amz-date' in request.headers
 

--- a/tests/unit/test_sigv4_helper.py
+++ b/tests/unit/test_sigv4_helper.py
@@ -85,6 +85,19 @@ class TestCreateAwsSession:
         assert result == mock_session
 
     @patch('boto3.Session')
+    def test_create_aws_session_with_profile_and_region(self, mock_session_class):
+        """Test creating AWS session with specific profile and region."""
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        result = create_aws_session(profile='test-profile', region='us-west-2')
+
+        mock_session_class.assert_called_once_with(
+            profile_name='test-profile', region_name='us-west-2'
+        )
+        assert result == mock_session
+
+    @patch('boto3.Session')
     def test_create_aws_session_no_credentials_returns_session(self, mock_session_class):
         """Test that session is returned even when no credentials are immediately available."""
         mock_session = Mock()


### PR DESCRIPTION
## Summary
- pass the already-resolved proxy region into `boto3.Session` creation
- let local botocore credential refresh reuse the proxy region instead of requiring separate env configuration
- update unit coverage for the region-aware session creation path

## Testing
- `git diff --check`
- local Python test dependencies were not available in this environment, so pytest could not be run here

Closes #342.
