### PR TITLE
fix: endpoint swallowing with multiple profiles

### DIFF
--- a/mcp_proxy_for_aws/cli.py
+++ b/mcp_proxy_for_aws/cli.py
@@ -81,6 +81,7 @@ Examples:
 
     parser.add_argument(
         'endpoint',
+        nargs='?',
         help='SigV4 MCP endpoint URL',
     )
 
@@ -185,4 +186,11 @@ Examples:
         help='Skip request signing when AWS credentials are unavailable instead of failing',
     )
 
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.endpoint is None:
+        if args.profiles and '://' in args.profiles[-1]:
+            args.endpoint = args.profiles.pop()
+        else:
+            parser.error('the following arguments are required: endpoint')
+
+    return args

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -83,11 +83,63 @@ class TestParseArgs:
         assert args.read_timeout == 90.0
         assert args.write_timeout == 120.0
 
-    @patch('sys.argv', ['mcp-proxy-for-aws'])
-    def test_parse_args_missing_endpoint(self):
+    @pytest.mark.parametrize(
+        'argv',
+        [
+            ['mcp-proxy-for-aws'],
+            ['mcp-proxy-for-aws', '--profile', 'prod', 'dev'],
+        ],
+    )
+    def test_parse_args_missing_endpoint(self, argv, capsys):
         """Test parsing fails when endpoint is missing."""
-        with pytest.raises(SystemExit):
+        with patch('sys.argv', argv), pytest.raises(SystemExit) as exc_info:
             parse_args()
+
+        assert exc_info.value.code == 2
+        assert (
+            'mcp-proxy-for-aws: error: the following arguments are required: endpoint'
+            in capsys.readouterr().err
+        )
+
+    @pytest.mark.parametrize(
+        ('argv', 'expected_profiles'),
+        [
+            (
+                ['mcp-proxy-for-aws', '--profile', 'prod', 'https://test.example.com'],
+                ['prod'],
+            ),
+            (
+                [
+                    'mcp-proxy-for-aws',
+                    '--profile',
+                    'prod',
+                    'dev',
+                    'https://test.example.com',
+                    '--region',
+                    'eu-west-1',
+                ],
+                ['prod', 'dev'],
+            ),
+        ],
+    )
+    def test_parse_args_profile_before_endpoint(self, argv, expected_profiles):
+        """Test parsing profiles specified before the endpoint."""
+        with patch('sys.argv', argv):
+            args = parse_args()
+
+        assert args.endpoint == 'https://test.example.com'
+        assert args.profiles == expected_profiles
+
+    @patch(
+        'sys.argv',
+        ['mcp-proxy-for-aws', 'https://test.example.com', '--profile', 'prod', 'dev'],
+    )
+    def test_parse_args_endpoint_before_profiles(self):
+        """Test that endpoint-first multi-profile parsing remains unchanged."""
+        args = parse_args()
+
+        assert args.endpoint == 'https://test.example.com'
+        assert args.profiles == ['prod', 'dev']
 
     @patch.dict('os.environ', {'AWS_PROFILE': 'env-profile'})
     @patch('sys.argv', ['mcp-proxy-for-aws', 'https://test.example.com'])


### PR DESCRIPTION
## Summary

Fixes #351

### Changes

`--profile` is defined with `nargs='+'`, so argparse greedily consumes every token that follows it. When `--profile` appeared before the positional `endpoint`, the endpoint URL was swallowed into the profiles list and the process exited with the misleading error `the following arguments are required: endpoint`.

This PR fixes the argument-ordering issue without breaking the documented multi-profile syntax (`--profile default dev staging`):

- The `endpoint` positional now uses `nargs='?'` so parsing no longer hard-fails when the endpoint is consumed by `--profile`.
- After parsing, if `endpoint` is unset and the last collected profile value contains `://`, it is reassigned to `endpoint` (profile names can never contain `://`, so this is unambiguous).
- If the endpoint is genuinely missing, `parser.error()` is raised with the original message, preserving the previous error text and exit code 2.

### User experience

**Before** (flag before endpoint fails, MCP server silently fails to launch):

```
$ mcp-proxy-for-aws --profile myprofile https://aws-mcp.us-east-1.api.aws/mcp
mcp-proxy-for-aws: error: the following arguments are required: endpoint
```

**After** (both orderings work, including with multiple profiles):

```
$ mcp-proxy-for-aws --profile myprofile https://aws-mcp.us-east-1.api.aws/mcp        # works
$ mcp-proxy-for-aws --profile default dev staging https://aws-mcp.us-east-1.api.aws/mcp  # works
$ mcp-proxy-for-aws https://aws-mcp.us-east-1.api.aws/mcp --profile myprofile        # still works
```

Omitting the endpoint entirely still produces the same error and exit code 2 as before.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

Added unit tests in `tests/unit/test_cli.py` covering `--profile` before the endpoint (single and multiple profiles) and the missing-endpoint error path. All 21 CLI tests pass; ruff lint/format clean.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
