### PR TITLE
fix: resolve AWS_REGION metadata from profile configuration

### DIFF
--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -34,7 +34,7 @@ from fastmcp import Client
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import Tool, ToolResult
-from mcp_proxy_for_aws.utils import create_transport_with_sigv4
+from mcp_proxy_for_aws.utils import create_transport_with_sigv4, determine_aws_region
 from typing import Any, cast
 from typing_extensions import override
 
@@ -67,7 +67,13 @@ class ProfileOverrideMiddleware(Middleware):
         disable_telemetry: bool = False,
         skip_auth: bool = False,
     ) -> None:
-        """Initialize the middleware with connection and profile configuration."""
+        """Initialize the middleware with connection and profile configuration.
+
+        ``metadata`` must be the user-supplied metadata only (without the computed
+        ``AWS_REGION`` default): each profile client injects its own ``AWS_REGION``
+        resolved from that profile's configuration, with user metadata taking
+        precedence.
+        """
         super().__init__()
         self._allowed_profiles = set(allowed_profiles)
         self._default_profile = default_profile
@@ -163,11 +169,15 @@ class ProfileOverrideMiddleware(Middleware):
         async with self._lock:
             if profile not in self._profile_clients:
                 logger.info('Creating dedicated connection for profile %s', profile)
+                metadata = {
+                    'AWS_REGION': determine_aws_region(self._endpoint, profile),
+                    **self._metadata,
+                }
                 transport = create_transport_with_sigv4(
                     self._endpoint,
                     self._service,
                     self._region,
-                    self._metadata,
+                    metadata,
                     self._timeout,
                     profile,
                     self._disable_telemetry,

--- a/mcp_proxy_for_aws/server.py
+++ b/mcp_proxy_for_aws/server.py
@@ -42,6 +42,7 @@ from mcp_proxy_for_aws.utils import (
     create_transport_with_sigv4,
     determine_aws_region,
     determine_service_name,
+    determine_signing_region,
 )
 
 
@@ -55,15 +56,6 @@ async def run_proxy(args) -> None:
     # Validate and determine service
     service = determine_service_name(args.endpoint, args.service)
     logger.debug('Using service: %s', service)
-
-    # Validate and determine region
-    region = determine_aws_region(args.endpoint, args.region)
-    logger.debug('Using region: %s', region)
-
-    # Build metadata dictionary - start with AWS_REGION, then merge user metadata
-    metadata = {'AWS_REGION': region}
-    if args.metadata:
-        metadata.update(args.metadata)
 
     # Get profile(s) from CLI args or env var.
     # AWS_MCP_PROXY_PROFILES: Space-separated list of AWS profile names for multi-account
@@ -81,10 +73,22 @@ async def run_proxy(args) -> None:
     # Dedup profiles, preserve order, include all (including default)
     all_profiles = list(dict.fromkeys(profiles))
 
+    # The signing region must match the endpoint; the metadata region tells the
+    # backend where to operate and follows the AWS CLI/boto3 resolution chain.
+    signing_region = determine_signing_region(args.endpoint, args.region)
+    region = determine_aws_region(args.endpoint, default_profile)
+    logger.debug('Using signing region: %s, region: %s', signing_region, region)
+
+    # Build metadata dictionary - start with AWS_REGION, then merge user metadata
+    metadata = {'AWS_REGION': region}
+    if args.metadata:
+        metadata.update(args.metadata)
+
     # Log server configuration
     logger.info(
-        'Using service: %s, region: %s, metadata: %s, profile: %s, switch profiles: %s',
+        'Using service: %s, signing region: %s, region: %s, metadata: %s, profile: %s, switch profiles: %s',
         service,
+        signing_region,
         region,
         metadata,
         default_profile,
@@ -102,7 +106,7 @@ async def run_proxy(args) -> None:
     transport = create_transport_with_sigv4(
         args.endpoint,
         service,
-        region,
+        signing_region,
         metadata,
         timeout,
         default_profile,
@@ -127,13 +131,14 @@ async def run_proxy(args) -> None:
         add_logging_middleware(proxy, args.log_level)
         add_tool_filtering_middleware(proxy, args.read_only)
 
+        # Pass user metadata only: the middleware resolves AWS_REGION per profile.
         profile_middleware = add_profile_override_middleware(
             proxy,
             all_profiles,
             default_profile,
             service,
-            region,
-            metadata,
+            signing_region,
+            args.metadata or {},
             timeout,
             args.endpoint,
             args.disable_telemetry,
@@ -183,7 +188,7 @@ def add_profile_override_middleware(
         default_profile: The default profile name (first in the list)
         service: The AWS service name
         region: The AWS region
-        metadata: The metadata dictionary
+        metadata: User-supplied metadata (AWS_REGION is resolved per profile by the middleware)
         timeout: The httpx timeout configuration
         endpoint: The MCP endpoint URL
         disable_telemetry: Whether to disable telemetry on profile transports

--- a/mcp_proxy_for_aws/utils.py
+++ b/mcp_proxy_for_aws/utils.py
@@ -19,7 +19,7 @@ import httpx
 import logging
 import os
 from fastmcp.client.transports import StreamableHttpTransport
-from mcp_proxy_for_aws.sigv4_helper import create_sigv4_client
+from mcp_proxy_for_aws.sigv4_helper import create_aws_session, create_sigv4_client
 from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -183,12 +183,52 @@ def determine_service_name(endpoint: str, service: Optional[str] = None) -> str:
     return determined_service
 
 
-def determine_aws_region(endpoint: str, region: Optional[str]) -> str:
-    """Validate and determine the AWS region.
+def determine_signing_region(endpoint: str, region: Optional[str]) -> str:
+    """Determine the AWS region to use for SigV4 signing.
+
+    The signature's credential scope must match the endpoint's region, so the
+    endpoint takes precedence over profile or environment configuration.
 
     Args:
         endpoint: The endpoint URL
         region: Optional region name
+
+    Returns:
+        Validated signing region
+
+    Raises:
+        ValueError: If region cannot be determined
+    """
+    if region:
+        logger.debug('Signing region determined through explicit parameter')
+        return region
+
+    # Parse AWS region from endpoint URL
+    _, endpoint_region = get_service_name_and_region_from_endpoint(endpoint)
+    if endpoint_region:
+        logger.debug('Signing region determined through endpoint URL')
+        return endpoint_region
+
+    environment_region = os.getenv('AWS_REGION')
+    if environment_region:
+        logger.debug('Signing region determined through environment variable')
+        return environment_region
+
+    raise ValueError(
+        f"Could not determine AWS region from endpoint '{endpoint}' or from environment variable AWS_REGION. "
+        'Please provide the region explicitly using --region argument.'
+    )
+
+
+def determine_aws_region(endpoint: str, profile: Optional[str] = None) -> str:
+    """Determine the AWS region the backend should operate in (injected as AWS_REGION metadata).
+
+    Resolution order matches the AWS CLI and boto3: the profile/environment
+    configuration chain, then the endpoint region as a fallback.
+
+    Args:
+        endpoint: The endpoint URL
+        profile: Optional AWS profile name
 
     Returns:
         Validated AWS region
@@ -196,9 +236,10 @@ def determine_aws_region(endpoint: str, region: Optional[str]) -> str:
     Raises:
         ValueError: If region cannot be determined
     """
-    if region:
-        logger.debug('Region determined through explicit parameter')
-        return region
+    session_region = create_aws_session(profile).region_name
+    if session_region:
+        logger.debug('Region determined through AWS configuration chain')
+        return session_region
 
     # Parse AWS region from endpoint URL
     _, endpoint_region = get_service_name_and_region_from_endpoint(endpoint)
@@ -206,14 +247,9 @@ def determine_aws_region(endpoint: str, region: Optional[str]) -> str:
         logger.debug('Region determined through endpoint URL')
         return endpoint_region
 
-    environment_region = os.getenv('AWS_REGION')
-    if environment_region:
-        logger.debug('Region determined through environment variable')
-        return environment_region
-
     raise ValueError(
-        f"Could not determine AWS region from endpoint '{endpoint}' or from environment variable AWS_REGION. "
-        'Please provide the region explicitly using --region argument.'
+        f"Could not determine AWS region from endpoint '{endpoint}', AWS configuration, "
+        'or environment. Please configure a region via AWS_REGION or your AWS profile.'
     )
 
 

--- a/tests/unit/test_profile_switcher.py
+++ b/tests/unit/test_profile_switcher.py
@@ -298,6 +298,10 @@ class TestGetProfileClient:
                 return_value=mock_transport,
             ),
             patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.determine_aws_region',
+                return_value='us-east-1',
+            ),
+            patch(
                 'mcp_proxy_for_aws.middleware.profile_switcher.Client',
                 return_value=mock_client,
             ),
@@ -652,6 +656,10 @@ class TestLockWithDeterministicSynchronization:
                 return_value=mock_transport,
             ),
             patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.determine_aws_region',
+                return_value='us-east-1',
+            ),
+            patch(
                 'mcp_proxy_for_aws.middleware.profile_switcher.Client',
                 return_value=mock_client,
             ),
@@ -777,7 +785,7 @@ class TestProfileClientTransportParams:
             default_profile='default-profile',
             service='bedrock-agentcore',
             region='eu-west-1',
-            metadata={'AWS_REGION': 'eu-west-1', 'custom': 'val'},
+            metadata={'custom': 'val'},
             timeout=httpx.Timeout(60),
             endpoint='https://bedrock-agentcore.eu-west-1.api.aws/mcp',
             disable_telemetry=True,
@@ -793,19 +801,61 @@ class TestProfileClientTransportParams:
                 return_value=mock_transport,
             ) as mock_create,
             patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.determine_aws_region',
+                return_value='sa-east-1',
+            ) as mock_determine_region,
+            patch(
                 'mcp_proxy_for_aws.middleware.profile_switcher.Client',
                 return_value=mock_client,
             ),
         ):
             await mw._get_profile_client('dev-profile')
 
+        # AWS_REGION is resolved from the switched profile's configuration,
+        # while the signing region stays pinned to the endpoint.
+        mock_determine_region.assert_called_once_with(
+            'https://bedrock-agentcore.eu-west-1.api.aws/mcp', 'dev-profile'
+        )
         mock_create.assert_called_once_with(
             'https://bedrock-agentcore.eu-west-1.api.aws/mcp',
             'bedrock-agentcore',
             'eu-west-1',
-            {'AWS_REGION': 'eu-west-1', 'custom': 'val'},
+            {'AWS_REGION': 'sa-east-1', 'custom': 'val'},
             httpx.Timeout(60),
             'dev-profile',
             True,
             True,
         )
+
+    @pytest.mark.asyncio
+    async def test_user_metadata_aws_region_wins_over_profile_region(self):
+        """A user-supplied AWS_REGION in --metadata overrides the profile's region."""
+        mw = ProfileOverrideMiddleware(
+            allowed_profiles=['default-profile', 'dev-profile'],
+            default_profile='default-profile',
+            service='lambda',
+            region='eu-west-1',
+            metadata={'AWS_REGION': 'us-west-2'},
+            timeout=httpx.Timeout(60),
+            endpoint='https://lambda.eu-west-1.api.aws/mcp',
+            disable_telemetry=False,
+            skip_auth=False,
+        )
+
+        with (
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.create_transport_with_sigv4',
+                return_value=Mock(),
+            ) as mock_create,
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.determine_aws_region',
+                return_value='sa-east-1',
+            ),
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.Client',
+                return_value=AsyncMock(),
+            ),
+        ):
+            await mw._get_profile_client('dev-profile')
+
+        assert mock_create.call_args[0][3] == {'AWS_REGION': 'us-west-2'}

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -69,9 +69,10 @@ class TestServer:
         mock_args.write_timeout = 180.0
         mock_args.log_level = 'INFO'
 
-        # Mock return values
+        # Mock return values — metadata region differs from the signing region
+        # (--region) to catch argument swaps between the two.
         mock_determine_service.return_value = 'test-service'
-        mock_determine_region.return_value = 'us-east-1'
+        mock_determine_region.return_value = 'sa-east-1'
 
         # Mock the transport and client factory
         mock_transport = Mock(spec=ClientTransport)
@@ -91,14 +92,14 @@ class TestServer:
 
         # Assert
         mock_determine_service.assert_called_once_with('https://test.example.com', 'test-service')
-        mock_determine_region.assert_called_once_with('https://test.example.com', 'us-east-1')
+        mock_determine_region.assert_called_once_with('https://test.example.com', None)
         # Verify create_transport was called (we check args differently since Timeout object comparison is complex)
         assert mock_create_transport.call_count == 1
         call_args = mock_create_transport.call_args
         assert call_args[0][0] == 'https://test.example.com'
         assert call_args[0][1] == 'test-service'
-        assert call_args[0][2] == 'us-east-1'
-        assert call_args[0][3] == {'AWS_REGION': 'us-east-1'}  # metadata
+        assert call_args[0][2] == 'us-east-1'  # signing region from --region
+        assert call_args[0][3] == {'AWS_REGION': 'sa-east-1'}  # metadata region from profile
         # call_args[0][4] is the Timeout object
         assert call_args[0][5] is None  # profile
         mock_client_factory_class.assert_called_once_with(mock_transport)
@@ -163,7 +164,7 @@ class TestServer:
 
         # Assert
         mock_determine_service.assert_called_once_with('https://test.example.com', 'test-service')
-        mock_determine_region.assert_called_once_with('https://test.example.com', 'us-east-1')
+        mock_determine_region.assert_called_once_with('https://test.example.com', 'test-profile')
         # Verify create_transport was called (we check args differently since Timeout object comparison is complex)
         assert mock_create_transport.call_count == 1
         call_args = mock_create_transport.call_args

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -20,6 +20,7 @@ from mcp_proxy_for_aws.utils import (
     create_transport_with_sigv4,
     determine_aws_region,
     determine_service_name,
+    determine_signing_region,
     validate_endpoint_url,
 )
 from unittest.mock import MagicMock, patch
@@ -298,8 +299,8 @@ class TestValidateRequiredArgs:
         assert endpoint in str(exc_info.value)
 
 
-class TestDetermineRegion:
-    """Test cases for determine_aws_region function."""
+class TestDetermineSigningRegion:
+    """Test cases for determine_signing_region function."""
 
     @patch('os.getenv')
     def test_determine_region_with_region(self, mock_getenv):
@@ -307,7 +308,7 @@ class TestDetermineRegion:
         endpoint = 'https://mcp.us-east-1.api.aws/mcp'
         region = 'custom-region'
 
-        result = determine_aws_region(endpoint, region)
+        result = determine_signing_region(endpoint, region)
 
         assert result == region
         # Environment variable should not be checked when region is provided
@@ -320,7 +321,7 @@ class TestDetermineRegion:
         expected_region = 'us-east-1'
         mock_getenv.return_value = None
 
-        result = determine_aws_region(endpoint, None)
+        result = determine_signing_region(endpoint, None)
 
         assert result == expected_region
         # Environment variable should not be checked when region can be parsed from endpoint
@@ -332,7 +333,7 @@ class TestDetermineRegion:
         expected_region = 'us-west-2'
         mock_getenv.return_value = None
 
-        result = determine_aws_region(endpoint, None)
+        result = determine_signing_region(endpoint, None)
 
         assert result == expected_region
         # Environment variable should not be checked when region can be parsed from endpoint
@@ -344,7 +345,7 @@ class TestDetermineRegion:
         mock_getenv.return_value = None
 
         with pytest.raises(ValueError) as exc_info:
-            determine_aws_region(endpoint, None)
+            determine_signing_region(endpoint, None)
 
         assert 'Could not determine AWS region' in str(exc_info.value)
         assert endpoint in str(exc_info.value)
@@ -359,8 +360,43 @@ class TestDetermineRegion:
         mock_getenv.return_value = 'us-west-1'
 
         # Act
-        result = determine_aws_region(endpoint, None)
+        result = determine_signing_region(endpoint, None)
 
         # Assert
         assert result == 'us-west-1'
         mock_getenv.assert_called_once_with('AWS_REGION')
+
+
+class TestDetermineRegion:
+    """Test cases for determine_aws_region function."""
+
+    @patch('mcp_proxy_for_aws.utils.create_aws_session')
+    def test_profile_region_wins_over_endpoint(self, mock_create_session):
+        """The AWS configuration chain takes precedence over the endpoint region."""
+        mock_create_session.return_value.region_name = 'sa-east-1'
+
+        result = determine_aws_region('https://mcp.eu-central-1.api.aws/mcp', 'my-profile')
+
+        assert result == 'sa-east-1'
+        mock_create_session.assert_called_once_with('my-profile')
+
+    @patch('mcp_proxy_for_aws.utils.create_aws_session')
+    def test_falls_back_to_endpoint_region(self, mock_create_session):
+        """Endpoint region is used when no region is configured."""
+        mock_create_session.return_value.region_name = None
+
+        result = determine_aws_region('https://mcp.eu-central-1.api.aws/mcp')
+
+        assert result == 'eu-central-1'
+        mock_create_session.assert_called_once_with(None)
+
+    @patch('mcp_proxy_for_aws.utils.create_aws_session')
+    def test_failure_when_region_undeterminable(self, mock_create_session):
+        """Raises when neither configuration nor endpoint yields a region."""
+        mock_create_session.return_value.region_name = None
+        endpoint = 'https://service.example.com'
+
+        with pytest.raises(ValueError) as exc_info:
+            determine_aws_region(endpoint)
+
+        assert 'Could not determine AWS region' in str(exc_info.value)


### PR DESCRIPTION
## Summary

Fixes #346

### Changes

The region injected as `AWS_REGION` metadata was always taken from the endpoint, ignoring the active profile's configured region. This change splits region resolution into two concerns:

- **Signing region** (`determine_signing_region`): unchanged behavior — endpoint region, with `--region` as override. The SigV4 credential scope must match the endpoint.
- **Metadata region** (`determine_aws_region`): now follows the AWS CLI/boto3 resolution chain — profile/environment configuration first, endpoint region as fallback.

Profile-switched clients (`aws_profile` tool parameter) also resolve `AWS_REGION` from their own profile instead of inheriting the default profile's region. User-supplied `--metadata AWS_REGION=...` still takes precedence.

### User experience

Before: with a profile configured for `sa-east-1` and endpoint `https://aws-mcp.eu-central-1.api.aws/mcp`, tools operated in `eu-central-1`.

After: tools operate in `sa-east-1`, matching AWS CLI/boto3 behavior. Users without a configured region keep the endpoint-region default.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

Unit tests cover the new resolution order, the profile-switcher per-profile region, and the user-metadata override precedence (250 tests passing).

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
