### PR TITLE
fix: disable follow_redirects in SigV4 httpx client

### DIFF
--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -203,7 +203,7 @@ def create_sigv4_client(
     """
     # Create a copy of kwargs to avoid modifying the passed dict
     client_kwargs = {
-        'follow_redirects': True,
+        'follow_redirects': False,
         'timeout': timeout,
         'limits': httpx.Limits(max_keepalive_connections=1, max_connections=5),
         **kwargs,


### PR DESCRIPTION
## Summary

### Changes

Sets `follow_redirects=False` as the default in the SigV4-signing httpx client.

The SigV4 request signing is implemented as an httpx request event hook. Because httpx re-fires
request hooks on every redirect hop, a 3xx redirect would cause the signing hook to re-sign the
request for the redirect target — potentially leaking the session token, access key ID, and
request payload to an unintended host.

> [!NOTE]
> This is a default-only change. FastMCP's `StreamableHttpTransport` [passes `follow_redirects=True`](https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/http.py#L180) via kwargs to the client factory, which overrides this default through `**kwargs` spread. So in practice this change is cosmetic until FastMCP removes that override. Regardless, redirects already fail today (see below) so there is no behavioral difference.

### User experience

No user-visible change. This is not a breaking change because:

1. **AWS endpoints do not issue HTTP redirects** — SigV4-protected services use DNS routing, not 3xx responses.

2. **Redirects already fail today** — even with `follow_redirects=True`, redirects are non-functional. When httpx builds a redirect request, it passes the original stream but does not set `_content` on the new [Request object](https://www.python-httpx.org/api/#request). The `_inject_metadata_hook` then accesses `request.content`, which raises `RequestNotRead` and aborts the request. This happens before the signing hook runs, regardless of `--skip-auth`.

3. **The MCP specification is silent on HTTP redirects** — no 3xx status codes are defined or mentioned in the [Streamable HTTP transport spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http). The SDK's `follow_redirects=True` default is a general-purpose convenience, not a protocol requirement.

### References

- [MCP Streamable HTTP Transport Specification (2025-03-26)](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http)
- [httpx redirect handling documentation](https://www.python-httpx.org/quickstart/#redirection)
- [httpx event hooks documentation](https://www.python-httpx.org/advanced/event-hooks/)
- [AWS SigV4 signing process](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html)
- [FastMCP `follow_redirects=True` override](https://github.com/PrefectHQ/fastmcp/blob/main/fastmcp_slim/fastmcp/client/transports/http.py#L180)

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Existing test suite passes
- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.