### PR TITLE
fix: stale profile refresh when using multi-profiles

### DIFF
--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -188,14 +188,34 @@ class ProfileOverrideMiddleware(Middleware):
                 self._profile_clients[profile] = client
             return self._profile_clients[profile]
 
+    async def _invalidate_profile_client(self, profile: str, failed_client: Client) -> None:
+        """Remove and disconnect a failed client if it is still cached."""
+        stale_client: Client | None = None
+        async with self._lock:
+            if self._profile_clients.get(profile) is failed_client:
+                stale_client = self._profile_clients.pop(profile)
+
+        if stale_client is not None:
+            try:
+                await stale_client.__aexit__(None, None, None)
+            except Exception:
+                logger.warning(
+                    'Failed to disconnect invalidated profile client %s',
+                    profile,
+                    exc_info=True,
+                )
+
     async def disconnect_profile_clients(self) -> None:
         """Disconnect all per-profile clients. Call during server shutdown."""
-        for profile, client in self._profile_clients.items():
+        async with self._lock:
+            profile_clients = list(self._profile_clients.items())
+            self._profile_clients.clear()
+
+        for profile, client in profile_clients:
             try:
                 await client.__aexit__(None, None, None)
             except Exception:
                 logger.exception('Failed to disconnect profile client %s', profile)
-        self._profile_clients.clear()
 
     async def _call_with_profile(
         self,
@@ -252,6 +272,7 @@ class ProfileOverrideMiddleware(Middleware):
             raise
         except Exception as e:
             logger.exception('Error calling tool via profile %s', profile)
+            await self._invalidate_profile_client(profile, client)
             raise ToolError(
                 f'Tool call failed using profile {profile!r}. '
                 'The request could not be completed with the specified profile.'

--- a/tests/unit/test_profile_switcher.py
+++ b/tests/unit/test_profile_switcher.py
@@ -271,6 +271,155 @@ class TestPerCallProfileOverride:
         assert 'backend error' not in str(exc_info.value)
 
 
+class TestProfileClientInvalidation:
+    """Tests for invalidating failed per-profile clients."""
+
+    @pytest.mark.asyncio
+    async def test_session_exception_invalidates_without_retry(self, middleware, mock_context):
+        """A failed session is removed and closed without replaying the tool call."""
+        client = AsyncMock()
+        original_error = ConnectionError('session closed')
+        client.call_tool.side_effect = original_error
+        middleware._profile_clients['dev-profile'] = client
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'aws___call_aws'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with pytest.raises(ToolError, match='Tool call failed') as exc_info:
+            await middleware.on_call_tool(mock_context, call_next)
+
+        assert exc_info.value.__cause__ is original_error
+        assert 'dev-profile' not in middleware._profile_clients
+        client.call_tool.assert_awaited_once_with(
+            'aws___call_aws', {'arg': 'value'}, raise_on_error=False
+        )
+        client.__aexit__.assert_awaited_once_with(None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_next_call_creates_fresh_client_after_invalidation(
+        self, middleware, mock_context
+    ):
+        """The call after invalidation connects and caches a fresh client."""
+        stale_client = AsyncMock()
+        stale_client.call_tool.side_effect = ConnectionError('session closed')
+        middleware._profile_clients['dev-profile'] = stale_client
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'aws___call_aws'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with pytest.raises(ToolError):
+            await middleware.on_call_tool(mock_context, call_next)
+
+        fresh_client = AsyncMock()
+        fresh_result = MagicMock()
+        fresh_result.content = []
+        fresh_result.structured_content = {'status': 'ok'}
+        fresh_result.meta = None
+        fresh_result.is_error = False
+        fresh_client.call_tool.return_value = fresh_result
+
+        with (
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.create_transport_with_sigv4',
+                return_value=Mock(),
+            ),
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.determine_aws_region',
+                return_value='us-east-1',
+            ),
+            patch(
+                'mcp_proxy_for_aws.middleware.profile_switcher.Client',
+                return_value=fresh_client,
+            ),
+        ):
+            result = await middleware.on_call_tool(mock_context, call_next)
+
+        assert result.structured_content == {'status': 'ok'}
+        assert middleware._profile_clients['dev-profile'] is fresh_client
+        stale_client.call_tool.assert_awaited_once()
+        fresh_client.__aenter__.assert_awaited_once_with()
+        fresh_client.call_tool.assert_awaited_once_with(
+            'aws___call_aws', {'arg': 'value'}, raise_on_error=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_cleanup_failure_does_not_mask_call_error(self, middleware, mock_context):
+        """Cleanup errors are swallowed and the original call error remains the cause."""
+        client = AsyncMock()
+        original_error = ConnectionError('session closed')
+        client.call_tool.side_effect = original_error
+        client.__aexit__.side_effect = RuntimeError('cleanup failed')
+        middleware._profile_clients['dev-profile'] = client
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'aws___call_aws'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with pytest.raises(ToolError, match='Tool call failed') as exc_info:
+            await middleware.on_call_tool(mock_context, call_next)
+
+        assert exc_info.value.__cause__ is original_error
+        assert 'dev-profile' not in middleware._profile_clients
+        client.__aexit__.assert_awaited_once_with(None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_is_error_result_does_not_invalidate_client(self, middleware, mock_context):
+        """A completed tool-level error leaves the profile session cached."""
+        client = AsyncMock()
+        call_result = MagicMock()
+        content_block = MagicMock()
+        content_block.text = 'backend error'
+        call_result.content = [content_block]
+        call_result.is_error = True
+        client.call_tool.return_value = call_result
+        middleware._profile_clients['dev-profile'] = client
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'aws___call_aws'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with pytest.raises(ToolError, match='backend error'):
+            await middleware.on_call_tool(mock_context, call_next)
+
+        assert middleware._profile_clients['dev-profile'] is client
+        client.__aexit__.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_old_client_failure_does_not_invalidate_replacement(
+        self, middleware, mock_context
+    ):
+        """A late failure from client A does not remove replacement client B."""
+        client_a = AsyncMock()
+        client_b = AsyncMock()
+        middleware._profile_clients['dev-profile'] = client_a
+
+        async def fail_after_replacement(*args, **kwargs):
+            async with middleware._lock:
+                middleware._profile_clients['dev-profile'] = client_b
+            raise ConnectionError('old session closed')
+
+        client_a.call_tool.side_effect = fail_after_replacement
+
+        mock_context.message = Mock()
+        mock_context.message.name = 'aws___call_aws'
+        mock_context.message.arguments = {'arg': 'value', 'aws_profile': 'dev-profile'}
+        call_next = AsyncMock()
+
+        with pytest.raises(ToolError, match='Tool call failed'):
+            await middleware.on_call_tool(mock_context, call_next)
+
+        assert middleware._profile_clients['dev-profile'] is client_b
+        client_a.call_tool.assert_awaited_once()
+        client_a.__aexit__.assert_not_awaited()
+        client_b.__aexit__.assert_not_awaited()
+
+
 class TestGetProfileClient:
     """Tests for the _get_profile_client method."""
 


### PR DESCRIPTION
## Summary

### Changes

Fixes #320. Per-profile MCP clients were cached forever with no invalidation, so a non-default profile whose session died during the credential-expiry window stayed broken until proxy restart (the default profile self-heals via `AWSMCPProxyClient._connect()`).

On a session-level failure, the middleware now removes and closes the cached client (identity-safe, only if it's still the failed instance) so the next call reconnects with fresh credentials. No automatic retry; tool-level errors (`is_error`) don't invalidate. `disconnect_profile_clients()` now snapshots the cache under the lock.

### User experience

Before: after credentials expire and are refreshed on disk, non-default profiles keep failing with "Tool call failed using profile ..." until the proxy is restarted.

After: the next call on that profile reconnects and succeeds.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

Five new unit tests: invalidation without replay, fresh-client reconnect on next call, cleanup failure not masking the original error, `is_error` results leaving the session cached, and a stale-client/replacement identity race.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
