### PR TITLE
feat(ci): Add SLSA provenance attestations to PyPI release workflow

### DIFF
--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Generate PEP 740 attestations for PyPI
         # Produces .publish.attestation sidecar files in dist/ which uv publish
         # automatically discovers and uploads to PyPI alongside the distributions.
-        run: uv tool run --exclude-newer "$(date -d '7 days ago' --utc +%Y-%m-%dT%H:%M:%SZ)" pypi-attestations sign dist/*
+        run: uv tool run --exclude-newer P7D pypi-attestations sign dist/*
 
       - name: Upload distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -57,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write    # Required for SLSA provenance signing via Sigstore
+      attestations: write # Required to write attestations to the GitHub repo
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -68,6 +70,16 @@ jobs:
 
       - name: Build distribution packages
         run: uv build
+
+      - name: Generate SLSA provenance attestations
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: dist/**
+
+      - name: Generate PEP 740 attestations for PyPI
+        # Produces .publish.attestation sidecar files in dist/ which uv publish
+        # automatically discovers and uploads to PyPI alongside the distributions.
+        run: uv tool run --exclude-newer "$(date -d '7 days ago' --utc +%Y-%m-%dT%H:%M:%SZ)" pypi-attestations sign dist/*
 
       - name: Upload distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test-pypi-publish.yml
+++ b/.github/workflows/test-pypi-publish.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write    # Required for SLSA provenance signing via Sigstore
+      attestations: write # Required to write attestations to the GitHub repo
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -42,6 +44,16 @@ jobs:
 
       - name: Build distribution packages
         run: uv build
+
+      - name: Generate SLSA provenance attestations
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: dist/**
+
+      - name: Generate PEP 740 attestations for PyPI
+        # Produces .publish.attestation sidecar files in dist/ which uv publish
+        # automatically discovers and uploads to PyPI alongside the distributions.
+        run: uv tool run --exclude-newer "$(date -d '7 days ago' --utc +%Y-%m-%dT%H:%M:%SZ)" pypi-attestations sign dist/*
 
       - name: Upload distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test-pypi-publish.yml
+++ b/.github/workflows/test-pypi-publish.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Generate PEP 740 attestations for PyPI
         # Produces .publish.attestation sidecar files in dist/ which uv publish
         # automatically discovers and uploads to PyPI alongside the distributions.
-        run: uv tool run --exclude-newer "$(date -d '7 days ago' --utc +%Y-%m-%dT%H:%M:%SZ)" pypi-attestations sign dist/*
+        run: uv tool run --exclude-newer P7D pypi-attestations sign dist/*
 
       - name: Upload distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary
  
  Add signed supply-chain attestations to the release artifacts (wheel + sdist) in both the
  production and test PyPI publish workflows. Two complementary attestations are generated in the
  `build` job:
  
  1. **SLSA build provenance** via `actions/attest-build-provenance`, using GitHub's OIDC token and
     Sigstore. This writes the attestation to the GitHub repo.
  2. **PEP 740 attestations for PyPI** via `pypi-attestations sign`, which produces
     `.publish.attestation` sidecar files in `dist/`. `uv publish` discovers and uploads these to
     PyPI alongside the distributions, so the `deploy` job needs no changes.
  
  The `pypi-attestations` tool is invoked through `uv tool run --exclude-newer "<7 days ago>"` so the
  attestation tooling itself is not pulled at a bleeding-edge (potentially compromised) version —
  consistent with our supply-chain hardening.
  
  ## Changes
  
  - `.github/workflows/pypi-publish-on-release.yml`:
    - added `id-token: write` and `attestations: write` to the `build` job permissions
    - added an `actions/attest-build-provenance@v2.4.0` step after `uv build` (SLSA provenance)
    - added a `pypi-attestations sign dist/*` step (PEP 740), run via `uv tool run --exclude-newer`
  - `.github/workflows/test-pypi-publish.yml`: same changes mirrored
  
  ## User experience
  
  No change to how customers install or run the proxy. Downstream, published artifacts now carry
  verifiable SLSA provenance and PEP 740 attestations, so consumers can confirm the artifacts were
  built by this repo's release workflow.
  
  ## Testing
  
  - YAML syntax validated locally; actionlint — no findings
  - `uv build` — produces wheel and sdist successfully
  - End-to-end: trigger the `Test PyPI Publishing` workflow on this branch and confirm both the
    Provenance attestation on the GitHub repo and the PEP 740 attestation section on
    https://test.pypi.org/p/mcp-proxy-for-aws