### PR TITLE
Add ruff TC and UP rules and fix the findings

### DIFF
--- a/mcp_proxy_for_aws/cli.py
+++ b/mcp_proxy_for_aws/cli.py
@@ -16,9 +16,10 @@
 
 import argparse
 import os
+from collections.abc import Sequence
 from mcp_proxy_for_aws import __version__
 from mcp_proxy_for_aws.utils import within_range
-from typing import Any, Dict, Optional, Sequence
+from typing import Any
 
 
 class KeyValueAction(argparse.Action):
@@ -29,7 +30,7 @@ class KeyValueAction(argparse.Action):
         parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
         values: str | Sequence[Any] | None,
-        option_string: Optional[str] = None,
+        option_string: str | None = None,
     ) -> None:
         """Parse key=value pairs into a dictionary.
 
@@ -39,7 +40,7 @@ class KeyValueAction(argparse.Action):
             values: The values to parse (list of key=value strings)
             option_string: The option string that triggered this action
         """
-        metadata: Dict[str, str] = {}
+        metadata: dict[str, str] = {}
         # Ensure values is a sequence
         if values is None:
             # No values provided, set empty dict

--- a/mcp_proxy_for_aws/client.py
+++ b/mcp_proxy_for_aws/client.py
@@ -25,7 +25,6 @@ from mcp.shared._httpx_utils import McpHttpClientFactory, create_mcp_http_client
 from mcp.shared.message import SessionMessage
 from mcp_proxy_for_aws.sigv4_helper import SigV4HTTPXAuth, _inject_metadata_hook
 from mcp_proxy_for_aws.utils import validate_endpoint_url
-from typing import Optional
 
 
 logger = logging.getLogger(__name__)
@@ -34,11 +33,11 @@ logger = logging.getLogger(__name__)
 def aws_iam_streamablehttp_client(
     endpoint: str,
     aws_service: str,
-    aws_region: Optional[str] = None,
-    aws_profile: Optional[str] = None,
-    credentials: Optional[Credentials] = None,
-    headers: Optional[dict[str, str]] = None,
-    metadata: Optional[dict[str, str]] = None,
+    aws_region: str | None = None,
+    aws_profile: str | None = None,
+    credentials: Credentials | None = None,
+    headers: dict[str, str] | None = None,
+    metadata: dict[str, str] | None = None,
     timeout: float | timedelta = 30,
     sse_read_timeout: float | timedelta = 60 * 5,
     terminate_on_close: bool = True,

--- a/mcp_proxy_for_aws/logging_config.py
+++ b/mcp_proxy_for_aws/logging_config.py
@@ -16,10 +16,9 @@
 
 import logging
 import sys
-from typing import Optional
 
 
-def configure_logging(level: Optional[str] = None) -> None:
+def configure_logging(level: str | None = None) -> None:
     """Configure logging with a standard format and optional level.
 
     Args:

--- a/mcp_proxy_for_aws/middleware/profile_switcher.py
+++ b/mcp_proxy_for_aws/middleware/profile_switcher.py
@@ -231,7 +231,7 @@ class ProfileOverrideMiddleware(Middleware):
             )
 
         # Strip aws_profile before forwarding to the backend
-        arguments: dict[str, Any] = dict(cast(dict[str, Any], context.message.arguments))
+        arguments: dict[str, Any] = dict(cast('dict[str, Any]', context.message.arguments))
         arguments.pop('aws_profile', None)
 
         # If it's the default profile, route through the normal middleware chain.

--- a/mcp_proxy_for_aws/middleware/tool_filter.py
+++ b/mcp_proxy_for_aws/middleware/tool_filter.py
@@ -14,11 +14,10 @@
 
 import logging
 import mcp.types as mt
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import Tool, ToolResult
-from typing import Sequence
 
 
 class ToolFilteringMiddleware(Middleware):

--- a/mcp_proxy_for_aws/proxy.py
+++ b/mcp_proxy_for_aws/proxy.py
@@ -38,7 +38,7 @@ class AWSMCPProxyClient(StatefulProxyClient):
         """Enter as normal && initialize only once."""
         logger.debug('Connecting %s', self)
         try:
-            result = await super(AWSMCPProxyClient, self)._connect()
+            result = await super()._connect()
             logger.debug('Connected %s', self)
             return result
         except httpx.HTTPStatusError as http_error:

--- a/mcp_proxy_for_aws/sigv4_helper.py
+++ b/mcp_proxy_for_aws/sigv4_helper.py
@@ -23,11 +23,12 @@ import time
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.credentials import BaseAssumeRoleCredentialFetcher, Credentials, ProcessProvider
+from collections.abc import Generator
 from functools import partial
 from httpx import __version__ as httpx_version
 from mcp_proxy_for_aws import __version__
 from mcp_proxy_for_aws.context import get_client_info
-from typing import Any, Dict, Generator, Optional
+from typing import Any
 
 
 logger = logging.getLogger(__name__)
@@ -85,7 +86,7 @@ _patch_default_role_session_name()
 SENSITIVE_HEADERS = frozenset({'authorization', 'x-amz-security-token', 'x-amz-date'})
 
 
-def _sanitize_headers(headers: Dict[str, str]) -> Dict[str, str]:
+def _sanitize_headers(headers: dict[str, str]) -> dict[str, str]:
     """Redact sensitive header values for safe logging.
 
     Args:
@@ -154,7 +155,7 @@ class SigV4HTTPXAuth(httpx.Auth):
         yield request
 
 
-def create_aws_session(profile: Optional[str] = None) -> boto3.Session:
+def create_aws_session(profile: str | None = None) -> boto3.Session:
     """Create an AWS session with optional profile.
 
     Args:
@@ -177,10 +178,10 @@ def create_aws_session(profile: Optional[str] = None) -> boto3.Session:
 def create_sigv4_client(
     service: str,
     region: str,
-    profile: Optional[str] = None,
-    timeout: Optional[httpx.Timeout] = None,
-    headers: Optional[Dict[str, str]] = None,
-    metadata: Optional[Dict[str, Any]] = None,
+    profile: str | None = None,
+    timeout: httpx.Timeout | None = None,
+    headers: dict[str, str] | None = None,
+    metadata: dict[str, Any] | None = None,
     disable_telemetry: bool = False,
     skip_auth: bool = False,
     **kwargs: Any,
@@ -294,7 +295,7 @@ async def _handle_error_response(response: httpx.Response) -> None:
 async def _sign_request_hook(
     region: str,
     service: str,
-    profile: Optional[str],
+    profile: str | None,
     skip_auth: bool,
     request: httpx.Request,
 ) -> None:
@@ -337,7 +338,7 @@ async def _sign_request_hook(
     logger.debug('Request headers after signing: %s', _sanitize_headers(dict(request.headers)))
 
 
-async def _inject_metadata_hook(metadata: Dict[str, Any], request: httpx.Request) -> None:
+async def _inject_metadata_hook(metadata: dict[str, Any], request: httpx.Request) -> None:
     """Request hook to inject metadata into MCP calls.
 
     Args:

--- a/mcp_proxy_for_aws/utils.py
+++ b/mcp_proxy_for_aws/utils.py
@@ -20,7 +20,7 @@ import logging
 import os
 from fastmcp.client.transports import StreamableHttpTransport
 from mcp_proxy_for_aws.sigv4_helper import create_aws_session, create_sigv4_client
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 from urllib.parse import urlparse
 
 
@@ -70,9 +70,9 @@ def create_transport_with_sigv4(
     url: str,
     service: str,
     region: str,
-    metadata: Dict[str, Any],
+    metadata: dict[str, Any],
     custom_timeout: httpx.Timeout,
-    profile: Optional[str] = None,
+    profile: str | None = None,
     disable_telemetry: bool = False,
     skip_auth: bool = False,
 ) -> StreamableHttpTransport:
@@ -93,9 +93,9 @@ def create_transport_with_sigv4(
     """
 
     def client_factory(
-        headers: Optional[Dict[str, str]] = None,
-        timeout: Optional[httpx.Timeout] = None,
-        auth: Optional[httpx.Auth] = None,
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
         **kw,
     ) -> httpx.AsyncClient:
         return create_sigv4_client(
@@ -117,7 +117,7 @@ def create_transport_with_sigv4(
     )
 
 
-def get_service_name_and_region_from_endpoint(endpoint: str) -> Tuple[str, str]:
+def get_service_name_and_region_from_endpoint(endpoint: str) -> tuple[str, str]:
     """Extract service name and region from an endpoint URL.
 
     Args:
@@ -154,7 +154,7 @@ def get_service_name_and_region_from_endpoint(endpoint: str) -> Tuple[str, str]:
             return '', ''
 
 
-def determine_service_name(endpoint: str, service: Optional[str] = None) -> str:
+def determine_service_name(endpoint: str, service: str | None = None) -> str:
     """Validate and determine the service name and possibly region from an endpoint.
 
     Args:
@@ -183,7 +183,7 @@ def determine_service_name(endpoint: str, service: Optional[str] = None) -> str:
     return determined_service
 
 
-def determine_signing_region(endpoint: str, region: Optional[str]) -> str:
+def determine_signing_region(endpoint: str, region: str | None) -> str:
     """Determine the AWS region to use for SigV4 signing.
 
     The signature's credential scope must match the endpoint's region, so the
@@ -220,7 +220,7 @@ def determine_signing_region(endpoint: str, region: Optional[str]) -> str:
     )
 
 
-def determine_aws_region(endpoint: str, profile: Optional[str] = None) -> str:
+def determine_aws_region(endpoint: str, profile: str | None = None) -> str:
     """Determine the AWS region the backend should operate in (injected as AWS_REGION metadata).
 
     Resolution order matches the AWS CLI and boto3: the profile/environment
@@ -253,7 +253,7 @@ def determine_aws_region(endpoint: str, profile: Optional[str] = None) -> str:
     )
 
 
-def within_range(min_value: float, max_value: Optional[float] = None):
+def within_range(min_value: float, max_value: float | None = None):
     """Factory function to create range validators.
 
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ force-exclude = true
 
 [tool.ruff.lint]
 exclude = ["__init__.py"]
-select = ["C", "D", "E", "F", "G", "I", "W"]
+select = ["C", "D", "E", "F", "G", "I", "TC", "UP", "W"]
 ignore = ["C901", "E501", "E741", "F402", "F823", "D100", "D106"]
 
 [tool.ruff.lint.isort]

--- a/tests/integ/mcp/simple_mcp_client.py
+++ b/tests/integ/mcp/simple_mcp_client.py
@@ -17,14 +17,13 @@ import fastmcp
 import logging
 from fastmcp.client import StdioTransport
 from fastmcp.client.elicitation import ElicitResult
-from typing import Dict, Optional
 
 
 logger = logging.getLogger(__name__)
 
 
 def build_mcp_client(
-    endpoint: str, region_name: str, metadata: Optional[Dict[str, str]] = None
+    endpoint: str, region_name: str, metadata: dict[str, str] | None = None
 ) -> fastmcp.Client:
     """Create a MCP Client with custom metadata.
 
@@ -62,7 +61,7 @@ async def _basic_elicitation_handler(message: str, response_type: type, params, 
     raise RuntimeError(f'Unknown Response-type, rather failing - {response_type}')
 
 
-def _build_mcp_config(endpoint: str, region_name: str, metadata: Optional[Dict[str, str]] = None):
+def _build_mcp_config(endpoint: str, region_name: str, metadata: dict[str, str] | None = None):
     credentials = boto3.Session().get_credentials()
 
     environment_variables = {
@@ -81,7 +80,7 @@ def _build_mcp_config(endpoint: str, region_name: str, metadata: Optional[Dict[s
     }
 
 
-def _build_args(endpoint: str, region_name: str, metadata: Optional[Dict[str, str]] = None):
+def _build_args(endpoint: str, region_name: str, metadata: dict[str, str] | None = None):
     """Build command line arguments for mcp-proxy-for-aws."""
     args = [
         endpoint,


### PR DESCRIPTION
## Summary

### Changes

Added Ruff rule selections for **`TC`** (flake8-type-checking / type-checking imports) and **`UP`** (pyupgrade) to the project's lint configuration. Modernized the codebase accordingly.applied pyupgrade transformations to bring syntax up to the minimum supported Python version.

### User experience

No user-facing changes. This is a developer-experience improvement, the codebase now uses more modern Python idioms and avoids unnecessary runtime imports that are only needed for static analysis.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [x] Yes
* [ ] No

If somehow this project was running in a Python 3.9 environment it won't work anymore, so I'm marking it as Breaking. But in Python 3.10+ it is _not_ breaking.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

All checks pass locally:
* `uv run ruff format .`
* `uv run ruff check .`
* `uv run pyright`
* `uv run pytest -m unit --cov`

No new integration test needed — this is a pure code-modernization / lint-config change with no behavioral impact.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.