### PR TITLE
fix: allow AWS_REGION override for credentials

### DIFF
--- a/mcp_proxy_for_aws/utils.py
+++ b/mcp_proxy_for_aws/utils.py
@@ -241,6 +241,11 @@ def determine_aws_region(endpoint: str, profile: Optional[str] = None) -> str:
         logger.debug('Region determined through AWS configuration chain')
         return session_region
 
+    environment_region = os.getenv('AWS_REGION')
+    if environment_region:
+        logger.debug('Region determined through environment variable `AWS_REGION`')
+        return environment_region
+
     # Parse AWS region from endpoint URL
     _, endpoint_region = get_service_name_and_region_from_endpoint(endpoint)
     if endpoint_region:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -380,6 +380,17 @@ class TestDetermineRegion:
         assert result == 'sa-east-1'
         mock_create_session.assert_called_once_with('my-profile')
 
+    @patch.dict('os.environ', {'AWS_REGION': 'ap-south-1'})
+    @patch('mcp_proxy_for_aws.utils.create_aws_session')
+    def test_environment_region_wins_over_endpoint(self, mock_create_session):
+        """AWS_REGION takes precedence over the endpoint region."""
+        mock_create_session.return_value.region_name = None
+
+        result = determine_aws_region('https://mcp.eu-central-1.api.aws/mcp')
+
+        assert result == 'ap-south-1'
+
+    @patch.dict('os.environ', {}, clear=True)
     @patch('mcp_proxy_for_aws.utils.create_aws_session')
     def test_falls_back_to_endpoint_region(self, mock_create_session):
         """Endpoint region is used when no region is configured."""
@@ -390,6 +401,7 @@ class TestDetermineRegion:
         assert result == 'eu-central-1'
         mock_create_session.assert_called_once_with(None)
 
+    @patch.dict('os.environ', {}, clear=True)
     @patch('mcp_proxy_for_aws.utils.create_aws_session')
     def test_failure_when_region_undeterminable(self, mock_create_session):
         """Raises when neither configuration nor endpoint yields a region."""


### PR DESCRIPTION
## Summary

### Changes

`determine_aws_region` resolved the metadata region from the boto3 config chain, then fell back to the endpoint region. Since botocore only reads `AWS_DEFAULT_REGION` and not `AWS_REGION`, a user-set `AWS_REGION` was silently ignored. This adds an explicit `AWS_REGION` lookup between the two, making the order: profile/boto3 chain → `AWS_REGION` → endpoint region. Signing is untouched.

### User experience

With `AWS_REGION=ap-south-1`, no region in the active profile, and endpoint `https://mcp.eu-central-1.api.aws/mcp`, the backend previously operated in `eu-central-1` (from the endpoint URL); now it uses `ap-south-1`. For endpoints without a region in the hostname, no region resolved at all, surfacing as `NoRegionError`.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

Added `test_environment_region_wins_over_endpoint` in `tests/unit/test_utils.py` covering the new precedence, and isolated `os.environ` in the two neighbouring tests so they don't depend on the runner's `AWS_REGION`. `uv run pytest -m unit` passes (260).

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
