### PR TITLE
fix: surface credential error message during initialization

### DIFF
--- a/mcp_proxy_for_aws/middleware/tool_error_middleware.py
+++ b/mcp_proxy_for_aws/middleware/tool_error_middleware.py
@@ -84,5 +84,7 @@ class ToolErrorMiddleware(Middleware):
                 403,
             ):
                 return True
+            if isinstance(current, ValueError) and 'credentials' in str(current).lower():
+                return True
             current = current.__cause__ or current.__context__
         return False

--- a/mcp_proxy_for_aws/proxy.py
+++ b/mcp_proxy_for_aws/proxy.py
@@ -61,6 +61,13 @@ class AWSMCPProxyClient(StatefulProxyClient):
             if isinstance(e.__cause__, McpError):
                 raise e.__cause__
 
+            if isinstance(e.__cause__, ValueError) and 'credentials' in str(e.__cause__).lower():
+                from mcp.types import INTERNAL_ERROR, ErrorData
+
+                raise McpError(
+                    error=ErrorData(code=INTERNAL_ERROR, message=str(e.__cause__)),
+                ) from e
+
             if retry > self._max_connect_retry:
                 raise e
 

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -237,3 +237,23 @@ async def test_proxy_client_max_connect_retry_default():
     mock_transport = Mock(spec=ClientTransport)
     client = AWSMCPProxyClient(mock_transport)
     assert client._max_connect_retry == 3
+
+
+@pytest.mark.asyncio
+async def test_proxy_client_connect_credential_error():
+    """Test connection converts RuntimeError wrapping credential ValueError to McpError."""
+    mock_transport = Mock(spec=ClientTransport)
+    client = AWSMCPProxyClient(mock_transport)
+
+    credential_error = ValueError(
+        'No AWS credentials available. Configure credentials or use --skip-auth to send unsigned requests.'
+    )
+    runtime_error = RuntimeError('Client failed to connect')
+    runtime_error.__cause__ = credential_error
+
+    with patch('mcp_proxy_for_aws.proxy.StatefulProxyClient._connect', side_effect=runtime_error):
+        with pytest.raises(McpError) as exc_info:
+            await client._connect()
+        assert exc_info.value.error.code == -32603
+        assert 'credentials' in exc_info.value.error.message.lower()
+        assert '--skip-auth' in exc_info.value.error.message

--- a/tests/unit/test_tool_error_middleware.py
+++ b/tests/unit/test_tool_error_middleware.py
@@ -156,3 +156,17 @@ class TestToolErrorMiddleware:
         with pytest.raises(ToolError) as exc_info:
             await middleware.on_call_tool(context, call_next)
         assert '--profile' not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_credential_error_from_missing_credentials_valueerror(self):
+        """ValueError about missing credentials is recognised as a credential error."""
+        middleware = _make_middleware()
+        call_next = AsyncMock(
+            side_effect=ValueError(
+                'No AWS credentials available. Configure credentials or use --skip-auth.'
+            )
+        )
+        context = _make_context()
+
+        with pytest.raises(ToolError, match='expired or invalid AWS credentials'):
+            await middleware.on_call_tool(context, call_next)


### PR DESCRIPTION
## Summary

### Changes

When AWS credentials are unavailable at startup, the proxy now returns a clear error message instead of a generic `JSON-RPC error: -32602: Invalid request parameters ("")`.

### User experience

Before:
```
JSON-RPC error: -32602: Invalid request parameters("")
```

After:
```
JSON-RPC error: -32603: No AWS credentials available. Configure credentials or use --skip-auth to send unsigned requests.
```

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

- [x] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?

Unit tests added. Manual testing by sending an initialize request with credentials blocked:

```bash
echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}' \
  | AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_ACCESS_KEY_ID="" AWS_SECRET_ACCESS_KEY="" AWS_SESSION_TOKEN="" \
    .venv/bin/mcp-proxy-for-aws "https://aws-mcp.us-east-1.api.aws/mcp" --metadata "AWS_REGION=us-west-2"
```

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.