### PR TITLE
feat: ship a version-pinned CLI distribution (mcp-proxy-for-aws-cli)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,13 @@ updates:
       day: "monday"
       time: "07:00"
       timezone: "Etc/UTC"
+    # Supply-chain cooldown: don't adopt a release until it has been public for a few days,
+    # so a compromised upload has time to be yanked before it reaches our lock (and, via
+    # the build-time pin hook, the published mcp-proxy-for-aws wrapper). This is the right
+    # home for the cooldown; `[tool.uv] exclude-newer` only accepts a fixed date, not a
+    # rolling window, so it cannot express this.
+    cooldown:
+      default-days: 3
     commit-message:
       prefix: "chore(deps): update uv"
     groups:
@@ -60,6 +67,9 @@ updates:
       day: "monday"
       time: "07:00"
       timezone: "Etc/UTC"
+    # See the cooldown note on the `uv` ecosystem above.
+    cooldown:
+      default-days: 3
     commit-message:
       prefix: "chore(deps): update pip"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,9 +30,10 @@ updates:
       timezone: "Etc/UTC"
     # Supply-chain cooldown: don't adopt a release until it has been public for a few days,
     # so a compromised upload has time to be yanked before it reaches our lock (and, via
-    # the build-time pin hook, the published mcp-proxy-for-aws wrapper). This is the right
-    # home for the cooldown; `[tool.uv] exclude-newer` only accepts a fixed date, not a
-    # rolling window, so it cannot express this.
+    # the build-time pin hook, the published mcp-proxy-for-aws wrapper). We keep the
+    # cooldown here rather than in uv's `exclude-newer` so it is independent of the uv
+    # version resolving the lock: recent uv can express a rolling window via an
+    # `exclude-newer` duration, but older uv rejects durations and silently drops the setting.
     cooldown:
       default-days: 3
     commit-message:

--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -68,8 +68,19 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
 
-      - name: Build distribution packages
+      # Two distributions are released from this one commit: the library (which holds the
+      # code) and the metadata-only `mcp-proxy-for-aws` wrapper that pins the library's
+      # exact runtime closure. The wrapper is deliberately outside the uv workspace -- its
+      # dependencies are derived from uv.lock at build time -- so neither `uv build` nor
+      # `uv build --all-packages` can see it. It needs its own invocation.
+      - name: Build the library distribution
         run: uv build
+
+      # `-o dist` is required, not cosmetic: `uv build <path>` defaults to <path>/dist, so
+      # without it the wrapper lands in packages/proxy/dist and every later step here
+      # (attestations, upload, publish) silently skips it -- they all glob ./dist.
+      - name: Build the pinned wrapper distribution
+        run: uv build packages/proxy -o dist
 
       - name: Generate SLSA provenance attestations
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
@@ -106,8 +117,19 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
 
-      - name: Publish to PyPI
-        run: uv publish
+      # Order matters. The wrapper's metadata contains `mcp-proxy-for-aws==<version>`,
+      # so publishing the wrapper first opens a window in which `uvx mcp-proxy-for-aws-cli`
+      # resolves the wrapper and then fails to find the code package it pins.
+      #
+      # The globs list only distributions: `pypi-attestations` wrote `.publish.attestation`
+      # sidecars into dist/, and uv discovers those itself rather than taking them as
+      # inputs. `mcp_proxy_for_aws-*` does not match `mcp_proxy_for_aws_cli-*` (the
+      # separator after `aws` differs), so the two steps stay disjoint.
+      - name: Publish the code package to PyPI
+        run: uv publish dist/mcp_proxy_for_aws-*.tar.gz dist/mcp_proxy_for_aws-*.whl
+
+      - name: Publish the pinned wrapper to PyPI
+        run: uv publish dist/mcp_proxy_for_aws_cli-*.tar.gz dist/mcp_proxy_for_aws_cli-*.whl
 
   trigger-ecr-publish:
     needs: [build, deploy]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,6 +3,7 @@ name: Python
 on:
   push:
   pull_request:
+  merge_group:
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -79,6 +80,14 @@ jobs:
 
       - name: Build package
         run: uv build
+
+      # The wrapper is outside the uv workspace, so the step above does not build it. Build
+      # it here so a release cannot be the first thing to run the pin hook: this is what
+      # catches a stale uv.lock, an empty export, or a pre-release in the runtime closure.
+      # `-o dist` so the wrapper joins the library in the uploaded distribution artifact
+      # (`uv build <path>` would otherwise default to packages/proxy/dist).
+      - name: Build the pinned wrapper package
+        run: uv build packages/proxy -o dist
 
       - name: Upload distribution
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test-pypi-publish.yml
+++ b/.github/workflows/test-pypi-publish.yml
@@ -42,8 +42,16 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
 
-      - name: Build distribution packages
+      # Mirrors the real release workflow: the pinned wrapper sits outside the uv
+      # workspace, so `uv build` alone would silently produce only the library. See the
+      # comment in pypi-publish-on-release.yml.
+      - name: Build the library distribution
         run: uv build
+
+      # `-o dist` is required: `uv build <path>` defaults to <path>/dist, which the later
+      # attestation/upload/publish steps (all globbing ./dist) would skip.
+      - name: Build the pinned wrapper distribution
+        run: uv build packages/proxy -o dist
 
       - name: Generate SLSA provenance attestations
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
@@ -79,5 +87,14 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
 
-      - name: Publish to TestPyPI
-        run: uv publish --publish-url https://test.pypi.org/legacy/
+      # Code package first: the wrapper pins `mcp-proxy-for-aws==<version>`, so the reverse
+      # order leaves the wrapper briefly unresolvable. See pypi-publish-on-release.yml.
+      - name: Publish the code package to TestPyPI
+        run: |
+          uv publish --publish-url https://test.pypi.org/legacy/ \
+            dist/mcp_proxy_for_aws-*.tar.gz dist/mcp_proxy_for_aws-*.whl
+
+      - name: Publish the pinned wrapper to TestPyPI
+        run: |
+          uv publish --publish-url https://test.pypi.org/legacy/ \
+            dist/mcp_proxy_for_aws_cli-*.tar.gz dist/mcp_proxy_for_aws_cli-*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ build
 # PyPI
 .pypirc
 
+# Pins baked into the mcp-proxy-for-aws sdist at build time (derived from uv.lock)
+packages/proxy/_runtime_pins.txt
+
 # Documentation
 /doc/_apidoc/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN yum update -y && \
     groupadd -r app && \
     useradd -r -g app -d /app app
 
-# Install mcp-proxy-for-aws from PyPI
-RUN python3.13 -m pip install mcp-proxy-for-aws
+# Install mcp-proxy-for-aws-cli (pinned, frozen tree) from PyPI
+RUN python3.13 -m pip install mcp-proxy-for-aws-cli
 
 # Get healthcheck script
 COPY ./docker-healthcheck.sh /usr/local/bin/docker-healthcheck.sh
@@ -46,4 +46,4 @@ USER app
 HEALTHCHECK --interval=60s --timeout=10s --start-period=10s --retries=3 CMD ["docker-healthcheck.sh"]
 
 # Application entrypoint
-ENTRYPOINT ["mcp-proxy-for-aws"]
+ENTRYPOINT ["mcp-proxy-for-aws-cli"]

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ For CLI and `uvx` use, install **`mcp-proxy-for-aws-cli`**. It is a thin, versio
 
 ```bash
 # Run the server (pinned CLI distribution)
-uvx mcp-proxy-for-aws-cli@1.7.0 <SigV4 MCP endpoint URL>
+uvx mcp-proxy-for-aws-cli@latest <SigV4 MCP endpoint URL>
 ```
 
-**Note:** It is recommended to pin to a specific version (e.g., `@1.7.0`) to ensure reproducible behavior. Using `@latest` may pull in breaking changes. Check [PyPI](https://pypi.org/project/mcp-proxy-for-aws-cli/) for the latest stable version.
+**Note:** Because `mcp-proxy-for-aws-cli` pins its entire dependency tree inside the package, even `@latest` installs a tested, frozen set. Check [PyPI](https://pypi.org/project/mcp-proxy-for-aws-cli/) for available versions.
 
 **Note:** The first run may take tens of seconds as `uvx` downloads and caches dependencies. Subsequent runs will start in seconds. Actual startup time depends on your network and hardware.
 
@@ -174,7 +174,7 @@ AWS_MCP_PROXY_PROFILES="prod-readonly dev staging" mcp-proxy-for-aws-cli https:/
   "mcpServers": {
     "aws": {
       "command": "uvx",
-      "args": ["mcp-proxy-for-aws-cli@1.7.0", "https://aws-mcp.us-east-1.api.aws/mcp"],
+      "args": ["mcp-proxy-for-aws-cli@latest", "https://aws-mcp.us-east-1.api.aws/mcp"],
       "env": {
         "AWS_MCP_PROXY_PROFILES": "prod-readonly dev staging"
       }
@@ -439,7 +439,7 @@ If your MCP client hangs waiting for a tool call response (e.g., due to an unres
 By default, the proxy signs all outgoing requests with [SigV4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html) using your local AWS credentials. If you need to connect to an MCP endpoint that does not require SigV4 credentials (e.g., a local development server or a publicly accessible endpoint), use the `--skip-auth` flag:
 
 ```bash
-uvx mcp-proxy-for-aws-cli@1.7.0 https://my-endpoint.example.com/mcp --skip-auth
+uvx mcp-proxy-for-aws-cli@latest https://my-endpoint.example.com/mcp --skip-auth
 ```
 
 When `--skip-auth` is set, the proxy sends requests without signing them if AWS credentials are unavailable. If credentials _are_ available, requests are still signed as usual — the flag only changes behavior when credentials cannot be resolved.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,14 @@ The **MCP Proxy for AWS** package provides two ways to connect AI applications t
 - Add MCP servers on AWS to your AI assistant's configuration
 - Use a command-line tool that runs as a bridge between your MCP client and AWS
 
+→ Install **`mcp-proxy-for-aws-cli`**, the version-pinned CLI distribution: it freezes the entire dependency tree to tested versions. See [MCP Proxy](#mcp-proxy).
+
 **Use as a library if you want to:**
 - Build AI agents programmatically using popular frameworks like LangChain, Strands Agents, or LlamaIndex
 - Integrate AWS IAM-secured MCP servers directly into your Python applications
 - Have fine-grained control over the MCP session lifecycle in your code
+
+→ Install **`mcp-proxy-for-aws`**, the library distribution: it keeps loose, co-resolvable dependency ranges so it resolves alongside your own dependencies. See [Programmatic Access](#programmatic-access).
 
 ## Prerequisites
 
@@ -53,12 +57,14 @@ The MCP Proxy serves as a lightweight, client-side bridge between MCP clients (A
 
 #### Using PyPi
 
+For CLI and `uvx` use, install **`mcp-proxy-for-aws-cli`**. It is a thin, version-pinned distribution: it freezes the proxy's entire transitive dependency tree to tested versions, so a fresh install cannot silently pull in a newer — possibly compromised — release of a dependency. (The unsuffixed `mcp-proxy-for-aws` is the library distribution with loose, co-resolvable ranges, for importing `mcp_proxy_for_aws` in your own code — see [Programmatic Access](#programmatic-access).)
+
 ```bash
-# Run the server
-uvx mcp-proxy-for-aws@1.6.0 <SigV4 MCP endpoint URL>
+# Run the server (pinned CLI distribution)
+uvx mcp-proxy-for-aws-cli@1.7.0 <SigV4 MCP endpoint URL>
 ```
 
-**Note:** It is recommended to pin to a specific version (e.g., `@1.6.0`) to ensure reproducible behavior. Using `@latest` may pull in breaking changes. Check [PyPI](https://pypi.org/project/mcp-proxy-for-aws/) for the latest stable version.
+**Note:** It is recommended to pin to a specific version (e.g., `@1.7.0`) to ensure reproducible behavior. Using `@latest` may pull in breaking changes. Check [PyPI](https://pypi.org/project/mcp-proxy-for-aws-cli/) for the latest stable version.
 
 **Note:** The first run may take tens of seconds as `uvx` downloads and caches dependencies. Subsequent runs will start in seconds. Actual startup time depends on your network and hardware.
 
@@ -147,10 +153,10 @@ The proxy supports per-call AWS profile switching, allowing agents to work acros
 
 ```bash
 # Via CLI flag (first profile is default, rest are switchable)
-mcp-proxy-for-aws https://aws-mcp.us-east-1.api.aws/mcp --profile prod-readonly dev staging
+mcp-proxy-for-aws-cli https://aws-mcp.us-east-1.api.aws/mcp --profile prod-readonly dev staging
 
 # Via environment variable (same behavior, for plugin integration)
-AWS_MCP_PROXY_PROFILES="prod-readonly dev staging" mcp-proxy-for-aws https://aws-mcp.us-east-1.api.aws/mcp
+AWS_MCP_PROXY_PROFILES="prod-readonly dev staging" mcp-proxy-for-aws-cli https://aws-mcp.us-east-1.api.aws/mcp
 ```
 
 **How it works:**
@@ -168,7 +174,7 @@ AWS_MCP_PROXY_PROFILES="prod-readonly dev staging" mcp-proxy-for-aws https://aws
   "mcpServers": {
     "aws": {
       "command": "uvx",
-      "args": ["mcp-proxy-for-aws@1.6.0", "https://aws-mcp.us-east-1.api.aws/mcp"],
+      "args": ["mcp-proxy-for-aws-cli@1.7.0", "https://aws-mcp.us-east-1.api.aws/mcp"],
       "env": {
         "AWS_MCP_PROXY_PROFILES": "prod-readonly dev staging"
       }
@@ -394,6 +400,8 @@ uv run main.py
 
 ### Installation
 
+For programmatic/library use, install **`mcp-proxy-for-aws`** — the distribution with loose, co-resolvable dependency ranges. (For CLI/`uvx` use, install `mcp-proxy-for-aws-cli` instead, which pins the whole dependency tree — see [MCP Proxy](#mcp-proxy).)
+
 The client library is included when you install the package:
 
 ```bash
@@ -431,7 +439,7 @@ If your MCP client hangs waiting for a tool call response (e.g., due to an unres
 By default, the proxy signs all outgoing requests with [SigV4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html) using your local AWS credentials. If you need to connect to an MCP endpoint that does not require SigV4 credentials (e.g., a local development server or a publicly accessible endpoint), use the `--skip-auth` flag:
 
 ```bash
-uvx mcp-proxy-for-aws@1.6.0 https://my-endpoint.example.com/mcp --skip-auth
+uvx mcp-proxy-for-aws-cli@1.7.0 https://my-endpoint.example.com/mcp --skip-auth
 ```
 
 When `--skip-auth` is set, the proxy sends requests without signing them if AWS credentials are unavailable. If credentials _are_ available, requests are still signed as usual — the flag only changes behavior when credentials cannot be resolved.

--- a/mcp_proxy_for_aws/__init__.py
+++ b/mcp_proxy_for_aws/__init__.py
@@ -18,4 +18,8 @@ from importlib.metadata import version as _metadata_version
 
 
 __all__ = ['__version__']
+
+# This module is distributed by `mcp-proxy-for-aws`. The `mcp-proxy-for-aws-cli`
+# distribution is a metadata-only wrapper that pins this one, so its version is
+# always identical; look up the distribution that actually installs this module.
 __version__ = _metadata_version('mcp-proxy-for-aws')

--- a/packages/proxy/LICENSE
+++ b/packages/proxy/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/packages/proxy/NOTICE
+++ b/packages/proxy/NOTICE
@@ -1,0 +1,2 @@
+mcp-proxy-for-aws
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -1,0 +1,41 @@
+# MCP Proxy for AWS (version-pinned distribution)
+
+`mcp-proxy-for-aws-cli` is the distribution to install for **CLI and `uvx` use**. It contains no
+code of its own: it is a thin wrapper that depends on
+[`mcp-proxy-for-aws`](https://pypi.org/project/mcp-proxy-for-aws/) — which owns the
+implementation — and pins that library **plus its entire runtime dependency tree** to exact
+versions.
+
+```bash
+uvx mcp-proxy-for-aws-cli@latest <SigV4 MCP endpoint URL>
+```
+
+Because every transitive dependency is pinned with `==`, a given release always installs the
+same tree and cannot silently pick up a newer release of a transitive dependency.
+
+> **Scope of the guarantee:** this is *version pinning, not hash verification*. It prevents
+> automatic adoption of a newer (possibly compromised) release; it does not cryptographically
+> verify the installed artifacts.
+
+## Which package should I install?
+
+| Use case | Install | Dependencies |
+|---|---|---|
+| CLI / `uvx` / MCP client config | `mcp-proxy-for-aws-cli` | Exact `==` pins (frozen tree) |
+| Importing from your own application | `mcp-proxy-for-aws` | Loose ranges, co-resolvable |
+
+Install `mcp-proxy-for-aws` if you import `mcp_proxy_for_aws` in your own project, so that
+its dependencies can resolve alongside yours. The import name is `mcp_proxy_for_aws` for both
+distributions.
+
+The pins shipped here are derived at build time from the `uv.lock` committed at the release
+tag, so they are reproducible from the repository.
+
+## Documentation
+
+See the [project README](https://github.com/aws/mcp-proxy-for-aws/blob/main/README.md) for
+configuration, authentication, and usage.
+
+## License
+
+Apache-2.0. See [LICENSE](https://github.com/aws/mcp-proxy-for-aws/blob/main/LICENSE).

--- a/packages/proxy/hatch_build.py
+++ b/packages/proxy/hatch_build.py
@@ -1,0 +1,255 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build hooks that pin `mcp-proxy-for-aws-cli` to the exact runtime tree in `uv.lock`.
+
+`mcp-proxy-for-aws-cli` is a metadata-only wrapper around `mcp-proxy-for-aws`. The
+library declares loose ranges so that programmatic users can co-resolve it with their own
+dependencies; the wrapper declares the entire runtime closure as `==` pins so that
+`uvx mcp-proxy-for-aws-cli@<version>` installs a frozen tree and cannot silently adopt a
+newer -- possibly compromised -- release of a transitive dependency.
+
+The pins are never hand-maintained. They are a deterministic projection of the workspace
+`uv.lock` computed at build time, so a dependency bump is an ordinary single-commit
+`uv.lock` change:
+
+* Building in the repo (the release path) shells out to `uv export`, scoped to the
+  library's runtime closure.
+* Building from the wrapper's sdist reads `_runtime_pins.txt`, which the sdist build hook
+  bakes in. This keeps sdist builds working without `uv` and without the workspace.
+
+The lock takes precedence whenever it is reachable; the baked file is strictly a fallback
+for the context that has no workspace.
+
+Published *wheels* carry fully static `Requires-Dist` metadata, so these hooks never run
+on an end user's machine.
+"""
+
+import re
+import subprocess  # nosec B404 - only used to run a fixed `uv export` argv (shell=False)
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from hatchling.metadata.plugin.interface import MetadataHookInterface
+from pathlib import Path
+from typing import Any, ClassVar
+
+
+#: Name of the distribution that actually contains the code.
+LIB_NAME = 'mcp-proxy-for-aws'
+
+#: Matches a PEP 440 pre-release/dev segment in a `name==version` pin (before any marker).
+#: A pinned pre-release makes the wrapper uninstallable without `--prerelease=allow`,
+#: which end users of `uvx mcp-proxy-for-aws-cli` cannot pass.
+_PRERELEASE_RE = re.compile(
+    r'==\s*[0-9][0-9.]*\s*(?:a|b|rc|alpha|beta|dev|pre)[0-9]*', re.IGNORECASE
+)
+
+
+def _reject_prereleases(pins: list[str]) -> list[str]:
+    """Fail the build if any pin is a pre-release; otherwise return the pins unchanged.
+
+    This is a release-blocking guard by design: an uninstallable published wrapper is worse
+    than a failed build. If a dependency's constraints ever force a pre-release into the
+    lock, the fix is to hold that bump (or wait for the stable release), not to relax the
+    guard -- see the `[tool.uv]` note in the root `pyproject.toml`.
+    """
+    offenders = [p for p in pins if _PRERELEASE_RE.search(p.split(';', 1)[0])]
+    if offenders:
+        raise RuntimeError(
+            'Refusing to build mcp-proxy-for-aws-cli: the pinned runtime closure contains '
+            'pre-release versions, which make the wrapper uninstallable without '
+            f'`--prerelease=allow` (which uvx/pip users cannot pass): {offenders}. '
+            'Re-lock without pre-releases (`uv lock`) and rebuild.'
+        )
+    return pins
+
+
+#: Pin list baked into the sdist so that from-sdist builds need neither uv nor the
+#: workspace. Relative to the wrapper's project root.
+BAKED_PINS_FILENAME = '_runtime_pins.txt'
+
+_PINS_HEADER = (
+    '# Generated at build time from the workspace uv.lock. Do not edit.\n'
+    f'# Exact runtime closure of {LIB_NAME}, used to pin mcp-proxy-for-aws-cli.\n'
+)
+
+
+def _expected_workspace_root(project_root: Path) -> Path:
+    """Return where the workspace root should be for a given wrapper project root.
+
+    Positional by design -- in the repository the wrapper lives at
+    `<workspace>/packages/proxy` -- and the caller verifies the lock is actually there.
+    Verification matters because neither failure mode is self-announcing: a non-existent
+    directory surfaces from `subprocess` as a `FileNotFoundError` indistinguishable from
+    "uv is not installed", and a directory that merely sits in the wrong place can still
+    succeed, since uv discovers workspaces by walking *up* from its working directory and
+    would quietly resolve against whichever lock it finds first.
+
+    Args:
+        project_root: The wrapper's project root (the directory holding its pyproject).
+
+    Returns:
+        The directory expected to contain the workspace `uv.lock`.
+    """
+    resolved = project_root.resolve()
+    parents = resolved.parents
+    return parents[1] if len(parents) > 1 else resolved
+
+
+def _export_runtime_closure(workspace_root: Path) -> list[str]:
+    """Return the library's exact runtime closure by asking uv to export it.
+
+    Scoping matters: `uv.lock` is the *whole* workspace resolution, which also contains
+    dev-dependency groups and the `examples/mcp-client/*` members' trees. Baking those in
+    would over-pin the wrapper by hundreds of packages and make it practically
+    uninstallable. `--package <lib> --no-dev` narrows the export to just the library's
+    runtime dependencies.
+
+    Args:
+        workspace_root: Directory containing the workspace `pyproject.toml` and `uv.lock`.
+
+    Returns:
+        Requirement strings such as `boto3==1.43.51`, with environment markers preserved.
+
+    Raises:
+        RuntimeError: If uv is unavailable, the export fails, or it yields no pins.
+    """
+    command = [
+        'uv',
+        'export',
+        # The lock is authoritative here; never let a build silently re-resolve it.
+        '--frozen',
+        '--package',
+        LIB_NAME,
+        '--no-dev',
+        '--no-hashes',
+        '--no-emit-workspace',
+        '--no-annotate',
+        '--no-header',
+    ]
+    try:
+        completed = subprocess.run(  # noqa: S603  # nosec B603 fixed argv, no shell
+            command,
+            cwd=workspace_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError as exc:
+        # The caller has already proved `cwd` holds a lock, so the only file left to be
+        # missing is the `uv` executable itself.
+        raise RuntimeError(
+            'Cannot pin mcp-proxy-for-aws-cli: `uv` was not found on PATH and no '
+            f'{BAKED_PINS_FILENAME} was bundled. Install uv to build from the repository.'
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        # Most often a stale lock: `uv export --frozen` refuses to run when uv.lock does
+        # not match the manifests. Surface uv's own message rather than a bare exit code.
+        raise RuntimeError(
+            'Cannot pin mcp-proxy-for-aws-cli: `uv export` failed in '
+            f'{workspace_root}. Run `uv lock` and rebuild.\n{exc.stderr.strip()}'
+        ) from exc
+
+    pins = [line.strip() for line in completed.stdout.splitlines() if '==' in line]
+    if not pins:
+        # Never publish a wrapper with an empty or partial pin set: that would silently
+        # ship an unpinned package, which is precisely what this package exists to avoid.
+        raise RuntimeError(
+            f'Cannot pin mcp-proxy-for-aws-cli: `uv export` returned no pins for {LIB_NAME}.'
+        )
+    return pins
+
+
+def _read_baked_pins(path: Path) -> list[str]:
+    """Read pins previously baked into the sdist by `SdistPinsBuildHook`."""
+    return [
+        line.strip()
+        for line in path.read_text(encoding='utf-8').splitlines()
+        if line.strip() and not line.startswith('#')
+    ]
+
+
+def resolve_runtime_pins(project_root: Path) -> list[str]:
+    """Resolve the library's runtime pins for whichever build context we are in.
+
+    Precedence is deliberate: the workspace lock wins whenever it is reachable, and
+    `_runtime_pins.txt` is only a fallback for the context that has no workspace (a build
+    from the wrapper's sdist). The other way round, a leftover pins file -- an ordinary,
+    gitignored by-product of any earlier sdist build -- would silently outrank the lock and
+    freeze a release against stale pins with no error at all.
+
+    Args:
+        project_root: The wrapper's project root (the directory holding its pyproject).
+
+    Returns:
+        The exact runtime closure of the library, with environment markers preserved.
+
+    Raises:
+        RuntimeError: If neither the workspace lock nor bundled pins are available.
+    """
+    workspace_root = _expected_workspace_root(project_root)
+    if (workspace_root / 'uv.lock').is_file():
+        return _reject_prereleases(_export_runtime_closure(workspace_root))
+
+    baked = project_root / BAKED_PINS_FILENAME
+    if baked.is_file():
+        return _reject_prereleases(_read_baked_pins(baked))
+
+    raise RuntimeError(
+        'Cannot pin mcp-proxy-for-aws-cli: found neither the workspace lock at '
+        f'{workspace_root / "uv.lock"} nor bundled pins at {baked}. Build the wrapper from '
+        'a full repository checkout, or from its sdist.'
+    )
+
+
+class PinnedDependenciesMetadataHook(MetadataHookInterface):
+    """Fill in the wrapper's `dependencies` with the frozen runtime tree."""
+
+    PLUGIN_NAME: ClassVar[str] = 'pinned-dependencies'
+
+    def update(self, metadata: dict[str, Any]) -> None:
+        """Set `dependencies` to the library plus its exact runtime closure.
+
+        Args:
+            metadata: Core project metadata to mutate in place.
+        """
+        # The wrapper and the library are released together from the same commit, so the
+        # wrapper's own version is the correct pin for the library.
+        metadata['dependencies'] = [
+            f'{LIB_NAME}=={metadata["version"]}',
+            *resolve_runtime_pins(Path(self.root)),
+        ]
+
+
+class SdistPinsBuildHook(BuildHookInterface):
+    """Bake the resolved pins into the sdist so it builds without uv or the workspace."""
+
+    PLUGIN_NAME: ClassVar[str] = 'sdist-pins'
+
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+        """Generate and force-include the pins file when building an sdist.
+
+        Args:
+            version: Build target version, unused.
+            build_data: Hatchling build data to mutate in place.
+        """
+        if self.target_name != 'sdist':
+            return
+        # Always regenerate: reusing an existing file would let a by-product of an earlier
+        # build decide what a later one ships.
+        pins_path = Path(self.root) / BAKED_PINS_FILENAME
+        pins_path.write_text(
+            _PINS_HEADER + '\n'.join(resolve_runtime_pins(Path(self.root))) + '\n',
+            encoding='utf-8',
+        )
+        build_data.setdefault('force_include', {})[str(pins_path)] = BAKED_PINS_FILENAME

--- a/packages/proxy/pyproject.toml
+++ b/packages/proxy/pyproject.toml
@@ -1,0 +1,75 @@
+# `mcp-proxy-for-aws-cli` is a metadata-only wrapper: it ships no code of its own and exists
+# to pin `mcp-proxy-for-aws` (which owns the code) together with the library's entire
+# runtime closure at exact `==` versions. The pins are derived from the workspace uv.lock
+# at build time by hatch_build.py, so there is no pin list to maintain by hand.
+#
+# CLI / uvx users install this package and get a frozen tree.
+# Library users install `mcp-proxy-for-aws` and get loose, co-resolvable ranges.
+#
+# NOTE: this package is intentionally excluded from the uv workspace (see the root
+# pyproject) because its dependencies are dynamic and derived from uv.lock.
+
+[project]
+name = "mcp-proxy-for-aws-cli"
+
+# Kept in lockstep with mcp-proxy-for-aws by commitizen; the derived metadata pins
+# `mcp-proxy-for-aws` to exactly this version.
+version = "1.6.4"
+
+description = "MCP Proxy for AWS (version-pinned CLI distribution)"
+readme = "README.md"
+requires-python = ">=3.10,<3.15"
+
+# Filled in at build time from uv.lock by hatch_build.py.
+dynamic = ["dependencies"]
+
+license = {text = "Apache-2.0"}
+license-files = ["LICENSE", "NOTICE"]
+authors = [
+    {name = "Amazon Web Services"},
+    {name = "MCP Proxy for AWS"},
+]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
+
+[project.urls]
+documentation = "https://github.com/aws/mcp-proxy-for-aws/blob/main/README.md"
+repository = "https://github.com/aws/mcp-proxy-for-aws.git"
+changelog = "https://github.com/aws/mcp-proxy-for-aws/blob/main/CHANGELOG.md"
+
+# Resolves via the module shipped by mcp-proxy-for-aws.
+[project.scripts]
+"mcp-proxy-for-aws-cli" = "mcp_proxy_for_aws.server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.custom]
+path = "hatch_build.py"
+
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
+
+# This package deliberately contains no Python module of its own, which Hatchling cannot
+# infer; bypass its file-selection heuristics to build a metadata-only wheel.
+[tool.hatch.build.targets.wheel]
+bypass-selection = true
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "hatch_build.py",
+    "pyproject.toml",
+    "README.md",
+    "LICENSE",
+    "NOTICE",
+]

--- a/packages/proxy/tests/test_hook.py
+++ b/packages/proxy/tests/test_hook.py
@@ -1,0 +1,337 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the build hooks that pin `mcp-proxy-for-aws` from `uv.lock`.
+
+These guard the properties that make the pinned distribution correct: the pins cover the
+library's runtime closure only, environment markers survive, and a build fails loudly
+rather than shipping a partially-pinned wrapper.
+"""
+
+import pytest
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # Python 3.10 has no tomllib.
+    import tomli as tomllib
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from hatch_build import (  # noqa: E402
+    BAKED_PINS_FILENAME,
+    LIB_NAME,
+    PinnedDependenciesMetadataHook,
+    SdistPinsBuildHook,
+    resolve_runtime_pins,
+)
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[3]
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+# Dev-only tooling from the `dev` dependency group. The wrapper pins runtime dependencies,
+# so none of these may leak into its metadata.
+DEV_ONLY_PACKAGES = ('pytest', 'ruff', 'pyright', 'commitizen', 'pre-commit', 'pytest-cov')
+
+# Packages that only reach the lock through the examples/mcp-client/* workspace members.
+EXAMPLE_ONLY_PACKAGES = ('langchain', 'llama-index', 'strands-agents', 'agent-framework')
+
+
+def _names(pins: list[str]) -> set[str]:
+    """Return the distribution names from a list of requirement strings."""
+    return {pin.split('==')[0].strip().lower() for pin in pins}
+
+
+def _wrapper_root_in_fake_workspace(tmp_path: Path) -> Path:
+    """Return a wrapper project root laid out inside a throwaway workspace with a lock.
+
+    The lock only has to exist: these tests stub out the `uv export` that would read it.
+    """
+    (tmp_path / 'uv.lock').write_text('', encoding='utf-8')
+    project = tmp_path / 'packages' / 'proxy'
+    project.mkdir(parents=True)
+    return project
+
+
+@pytest.fixture(scope='module')
+def repo_pins() -> list[str]:
+    """The runtime pins derived from the repository's committed uv.lock."""
+    return resolve_runtime_pins(PROJECT_ROOT)
+
+
+class TestResolveRuntimePins:
+    """Deriving pins from the workspace lock."""
+
+    @pytest.mark.unit
+    def test_derives_pins_from_workspace_lock(self, repo_pins: list[str]) -> None:
+        """The repository checkout yields a non-trivial set of exact pins."""
+        assert repo_pins
+        assert all('==' in pin for pin in repo_pins)
+        # The real closure is ~83 packages; a handful would mean the export was mis-scoped.
+        assert len(repo_pins) > 50
+
+    @pytest.mark.unit
+    def test_pins_include_the_direct_runtime_dependencies(self, repo_pins: list[str]) -> None:
+        """The library's own declared runtime dependencies are present."""
+        assert {'boto3', 'botocore', 'fastmcp'} <= _names(repo_pins)
+
+    @pytest.mark.unit
+    def test_pins_are_exact_versions(self, repo_pins: list[str]) -> None:
+        """No pin uses a range operator, which would defeat the freeze."""
+        for pin in repo_pins:
+            requirement = pin.split(';')[0]
+            assert '==' in requirement, pin
+            assert not any(op in requirement for op in ('>=', '<=', '~=', '>', '<', '!=')), pin
+
+    @pytest.mark.unit
+    def test_environment_markers_are_preserved(self, repo_pins: list[str]) -> None:
+        """Platform-specific pins keep their markers so they do not over-constrain.
+
+        Without markers, a pin such as `colorama; sys_platform == 'win32'` would apply
+        everywhere and could make the wrapper uninstallable off that platform.
+        """
+        marked = [pin for pin in repo_pins if ';' in pin]
+        assert marked, 'expected at least one marker-qualified pin'
+        assert any('python_full_version' in pin or 'sys_platform' in pin for pin in marked)
+
+    @pytest.mark.unit
+    def test_excludes_dev_dependency_groups(self, repo_pins: list[str]) -> None:
+        """Dev tooling must not be pinned as a runtime dependency of the wrapper."""
+        leaked = _names(repo_pins) & set(DEV_ONLY_PACKAGES)
+        assert not leaked, f'dev-only packages leaked into runtime pins: {sorted(leaked)}'
+
+    @pytest.mark.unit
+    def test_excludes_example_workspace_member_trees(self, repo_pins: list[str]) -> None:
+        """The example clients' dependency trees must not be pinned either.
+
+        `uv.lock` covers the whole workspace, so an unscoped export would bake in these
+        trees and over-pin the wrapper by hundreds of packages.
+        """
+        leaked = _names(repo_pins) & set(EXAMPLE_ONLY_PACKAGES)
+        assert not leaked, f'example-only packages leaked into runtime pins: {sorted(leaked)}'
+
+    @pytest.mark.unit
+    def test_excludes_the_workspace_members_themselves(self, repo_pins: list[str]) -> None:
+        """Workspace members are not published deps and must be excluded."""
+        assert LIB_NAME not in _names(repo_pins)
+        assert not any(name.startswith('mcp-client-example') for name in _names(repo_pins))
+
+    @pytest.mark.unit
+    def test_is_deterministic(self) -> None:
+        """The same lock always projects to the same pins, in the same order."""
+        assert resolve_runtime_pins(PROJECT_ROOT) == resolve_runtime_pins(PROJECT_ROOT)
+
+    @pytest.mark.unit
+    def test_prefers_baked_pins_when_there_is_no_workspace(self, tmp_path: Path) -> None:
+        """A bundled pins file is used verbatim, without invoking uv.
+
+        This is the from-sdist path: the project has no workspace lock above it.
+        """
+        project = tmp_path / 'packages' / 'proxy'
+        project.mkdir(parents=True)
+        (project / BAKED_PINS_FILENAME).write_text(
+            '# generated\nboto3==1.2.3\ncolorama==0.4.6 ; sys_platform == "win32"\n',
+            encoding='utf-8',
+        )
+        with patch('hatch_build.subprocess.run') as mock_run:
+            pins = resolve_runtime_pins(project)
+        mock_run.assert_not_called()
+        assert pins == ['boto3==1.2.3', 'colorama==0.4.6 ; sys_platform == "win32"']
+
+    @pytest.mark.unit
+    def test_workspace_lock_outranks_a_leftover_pins_file(self, tmp_path: Path) -> None:
+        """The lock wins whenever it is reachable, even if a pins file is lying around.
+
+        `_runtime_pins.txt` is a gitignored by-product of any earlier sdist build, so it is
+        routinely present in a working tree. If it outranked the lock, a build would ship
+        those stale pins -- silently, and with no way to tell from the artifact.
+        """
+        (tmp_path / 'uv.lock').write_text('', encoding='utf-8')
+        project = tmp_path / 'packages' / 'proxy'
+        project.mkdir(parents=True)
+        (project / BAKED_PINS_FILENAME).write_text('boto3==0.0.1\n', encoding='utf-8')
+        completed = subprocess.CompletedProcess(['uv'], 0, stdout='boto3==1.2.3\n', stderr='')
+
+        with patch('hatch_build.subprocess.run', return_value=completed) as mock_run:
+            pins = resolve_runtime_pins(project)
+
+        mock_run.assert_called_once()
+        assert pins == ['boto3==1.2.3']
+
+
+class TestResolveRuntimePinsFailures:
+    """A build must fail loudly rather than emit an unpinned wrapper."""
+
+    @pytest.mark.unit
+    def test_raises_when_neither_lock_nor_baked_pins_exist(self, tmp_path: Path) -> None:
+        """A partial checkout names both missing inputs instead of blaming a missing uv.
+
+        Without the check they are indistinguishable: `subprocess` reports a non-existent
+        `cwd` as `FileNotFoundError`, exactly as it reports an absent executable.
+        """
+        project = tmp_path / 'packages' / 'proxy'
+        project.mkdir(parents=True)
+        with (
+            patch('hatch_build.subprocess.run') as mock_run,
+            pytest.raises(RuntimeError, match='found neither the workspace lock'),
+        ):
+            resolve_runtime_pins(project)
+        mock_run.assert_not_called()
+
+    @pytest.mark.unit
+    def test_raises_when_uv_export_fails(self, tmp_path: Path) -> None:
+        """A failing `uv export` (for example a stale lock) surfaces uv's message."""
+        project = _wrapper_root_in_fake_workspace(tmp_path)
+        error = subprocess.CalledProcessError(2, ['uv'], stderr='the lockfile is outdated')
+        with (
+            patch('hatch_build.subprocess.run', side_effect=error),
+            pytest.raises(RuntimeError, match='the lockfile is outdated'),
+        ):
+            resolve_runtime_pins(project)
+
+    @pytest.mark.unit
+    def test_raises_when_uv_is_unavailable(self, tmp_path: Path) -> None:
+        """No uv and no bundled pins is an error, not an empty dependency list."""
+        project = _wrapper_root_in_fake_workspace(tmp_path)
+        with (
+            patch('hatch_build.subprocess.run', side_effect=FileNotFoundError),
+            pytest.raises(RuntimeError, match='uv'),
+        ):
+            resolve_runtime_pins(project)
+
+    @pytest.mark.unit
+    def test_raises_when_export_yields_no_pins(self, tmp_path: Path) -> None:
+        """An empty export must not silently produce an unpinned wrapper.
+
+        Observed for real: `uv export --frozen` can succeed while returning nothing useful,
+        which would otherwise ship a wrapper that pins only the library.
+        """
+        project = _wrapper_root_in_fake_workspace(tmp_path)
+        completed = subprocess.CompletedProcess(['uv'], 0, stdout='# comment only\n', stderr='')
+        with (
+            patch('hatch_build.subprocess.run', return_value=completed),
+            pytest.raises(RuntimeError, match='no pins'),
+        ):
+            resolve_runtime_pins(project)
+
+
+class TestPinnedDependenciesMetadataHook:
+    """The metadata hook's contribution to the built distribution."""
+
+    @pytest.mark.unit
+    def test_sets_dependencies_with_lib_pinned_first(self) -> None:
+        """Dependencies are the version-locked library followed by its closure."""
+        hook = PinnedDependenciesMetadataHook(str(PROJECT_ROOT), {})
+        metadata: dict = {'version': '9.9.9'}
+        hook.update(metadata)
+
+        assert metadata['dependencies'][0] == f'{LIB_NAME}==9.9.9'
+        assert len(metadata['dependencies']) > 50
+
+    @pytest.mark.unit
+    def test_pins_library_to_the_wrapper_version(self) -> None:
+        """The two distributions are released in lockstep from the same commit."""
+        hook = PinnedDependenciesMetadataHook(str(PROJECT_ROOT), {})
+        metadata: dict = {'version': '1.2.3'}
+        hook.update(metadata)
+
+        assert f'{LIB_NAME}==1.2.3' in metadata['dependencies']
+        assert sum(1 for d in metadata['dependencies'] if d.startswith(LIB_NAME)) == 1
+
+
+class TestSdistPinsBuildHook:
+    """Baking pins into the sdist so it builds without uv or the workspace."""
+
+    @pytest.mark.unit
+    def test_writes_and_force_includes_pins_for_sdist(self, tmp_path: Path) -> None:
+        """Building an sdist generates the pins file and ships it at the root.
+
+        The hook writes into its *root*, so the root is a throwaway directory here. Using
+        the real project root would drop `_runtime_pins.txt` into the working tree, and an
+        interrupted run would leave it there -- where `resolve_runtime_pins` prefers it over
+        the lock and would silently freeze every later build against stale pins.
+        """
+        hook = SdistPinsBuildHook(
+            str(tmp_path),  # root: where the pins file is written
+            {},
+            {},
+            None,
+            str(tmp_path / 'dist'),  # directory: build output, unused by this hook
+            'sdist',  # type: ignore[arg-type]
+        )
+        build_data: dict = {}
+        with patch('hatch_build.resolve_runtime_pins', return_value=['boto3==1.2.3']):
+            hook.initialize('standard', build_data)
+
+        pins_path = tmp_path / BAKED_PINS_FILENAME
+        assert pins_path.is_file()
+        assert build_data['force_include'][str(pins_path)] == BAKED_PINS_FILENAME
+        assert 'boto3==1.2.3' in pins_path.read_text(encoding='utf-8')
+
+    @pytest.mark.unit
+    def test_does_nothing_for_wheel_target(self, tmp_path: Path) -> None:
+        """Wheels get their pins through the metadata hook, so nothing is bundled."""
+        hook = SdistPinsBuildHook(
+            str(tmp_path),
+            {},
+            {},
+            None,
+            str(tmp_path),
+            'wheel',  # type: ignore[arg-type]
+        )
+        build_data: dict = {}
+        hook.initialize('standard', build_data)
+
+        assert build_data == {}
+        assert not (tmp_path / BAKED_PINS_FILENAME).exists()
+
+
+class TestPackagingInvariants:
+    """Properties of the checked-in package configuration."""
+
+    @pytest.mark.unit
+    def test_license_files_match_the_repository_originals(self) -> None:
+        """The wrapper needs its own copies (sdists cannot escape their root).
+
+        Guards against the copies drifting from the canonical files at the repo root.
+        """
+        for filename in ('LICENSE', 'NOTICE'):
+            assert (PROJECT_ROOT / filename).read_bytes() == (
+                WORKSPACE_ROOT / filename
+            ).read_bytes(), f'packages/proxy/{filename} has drifted from the repository root'
+
+    @pytest.mark.unit
+    def test_wrapper_version_matches_library_version(self) -> None:
+        """Lockstep versioning; the wrapper pins the library to its own version."""
+
+        def version_of(pyproject: Path) -> str:
+            with pyproject.open('rb') as handle:
+                return tomllib.load(handle)['project']['version']
+
+        assert version_of(PROJECT_ROOT / 'pyproject.toml') == version_of(
+            WORKSPACE_ROOT / 'pyproject.toml'
+        )
+
+    @pytest.mark.unit
+    def test_wrapper_is_excluded_from_the_uv_workspace(self) -> None:
+        """Membership would make `uv lock` build metadata from the lock it is writing."""
+        with (WORKSPACE_ROOT / 'pyproject.toml').open('rb') as handle:
+            workspace = tomllib.load(handle)['tool']['uv']['workspace']
+
+        assert 'packages/proxy' in workspace.get('exclude', [])

--- a/packages/proxy/tests/test_packaging.py
+++ b/packages/proxy/tests/test_packaging.py
@@ -1,0 +1,181 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end packaging tests for the two published distributions.
+
+These run real `uv build` invocations, so they are marked `integ` rather than `unit`. They
+assert the properties users actually depend on: the library wheel contains the code, and the
+wrapper wheel carries fully static exact pins -- including when built from its own sdist,
+which is the context where the metadata hook cannot reach the workspace.
+"""
+
+import pytest
+import shutil
+import subprocess
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[3]
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+pytestmark = pytest.mark.integ
+
+
+def _uv_build(args: list[str], cwd: Path, env: dict | None = None) -> None:
+    """Run `uv build`, failing the test with uv's own output if it errors."""
+    result = subprocess.run(
+        ['uv', 'build', *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        pytest.fail(f'uv build {" ".join(args)} failed:\n{result.stdout}\n{result.stderr}')
+
+
+def _requires_dist(wheel: Path) -> list[str]:
+    """Return the `Requires-Dist` entries from a wheel's static METADATA."""
+    with zipfile.ZipFile(wheel) as archive:
+        name = next(n for n in archive.namelist() if n.endswith('.dist-info/METADATA'))
+        text = archive.read(name).decode('utf-8')
+    prefix = 'Requires-Dist:'
+    return [line[len(prefix) :].strip() for line in text.splitlines() if line.startswith(prefix)]
+
+
+@pytest.fixture(scope='module')
+def built_distributions(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build both distributions the way the release workflow does."""
+    out = tmp_path_factory.mktemp('dist')
+    _uv_build(['--all-packages', '--out-dir', str(out)], cwd=WORKSPACE_ROOT)
+    _uv_build(['--out-dir', str(out), '.'], cwd=PROJECT_ROOT)
+    return out
+
+
+def _single(directory: Path, pattern: str) -> Path:
+    matches = sorted(directory.glob(pattern))
+    assert len(matches) == 1, f'expected exactly one {pattern}, found {matches}'
+    return matches[0]
+
+
+class TestLibraryDistribution:
+    """`mcp-proxy-for-aws` owns the code."""
+
+    def test_wheel_contains_the_importable_module(self, built_distributions: Path) -> None:
+        """Guards uv#7227: a name/package mismatch can silently ship an empty wheel."""
+        wheel = _single(built_distributions, 'mcp_proxy_for_aws-*.whl')
+        with zipfile.ZipFile(wheel) as archive:
+            modules = [n for n in archive.namelist() if n.startswith('mcp_proxy_for_aws/')]
+
+        assert 'mcp_proxy_for_aws/__init__.py' in modules
+        assert 'mcp_proxy_for_aws/server.py' in modules
+
+    def test_dependencies_stay_loose(self, built_distributions: Path) -> None:
+        """Library users must be able to co-resolve it with their own dependencies."""
+        wheel = _single(built_distributions, 'mcp_proxy_for_aws-*.whl')
+        requirements = _requires_dist(wheel)
+
+        assert requirements
+        assert not any('==' in requirement for requirement in requirements)
+
+
+class TestWrapperDistribution:
+    """`mcp-proxy-for-aws-cli` is a metadata-only pinned wrapper."""
+
+    def test_wheel_ships_no_modules(self, built_distributions: Path) -> None:
+        """All code comes from the library; the wrapper is metadata plus an entry point."""
+        wheel = _single(built_distributions, 'mcp_proxy_for_aws_cli-*.whl')
+        with zipfile.ZipFile(wheel) as archive:
+            names = archive.namelist()
+
+        assert not [n for n in names if not n.startswith('mcp_proxy_for_aws_cli-')]
+        assert any(n.endswith('entry_points.txt') for n in names)
+
+    def test_wheel_pins_the_entire_runtime_tree(self, built_distributions: Path) -> None:
+        """Every dependency is an exact pin, so a release installs a frozen tree."""
+        wheel = _single(built_distributions, 'mcp_proxy_for_aws_cli-*.whl')
+        requirements = _requires_dist(wheel)
+
+        # The library's runtime closure is ~83 packages plus the library itself.
+        assert len(requirements) > 50
+        for requirement in requirements:
+            assert '==' in requirement.split(';')[0], requirement
+
+    def test_wheel_pins_the_library_at_the_matching_version(
+        self, built_distributions: Path
+    ) -> None:
+        """The wrapper and library are released in lockstep."""
+        wheel = _single(built_distributions, 'mcp_proxy_for_aws_cli-*.whl')
+        version = wheel.name.split('-')[1]
+
+        assert f'mcp-proxy-for-aws=={version}' in _requires_dist(wheel)
+
+    def test_wheel_preserves_environment_markers(self, built_distributions: Path) -> None:
+        """Platform-specific pins keep their markers rather than applying everywhere."""
+        wheel = _single(built_distributions, 'mcp_proxy_for_aws_cli-*.whl')
+
+        assert [r for r in _requires_dist(wheel) if ';' in r]
+
+    def test_sdist_bundles_the_derived_pins(self, built_distributions: Path) -> None:
+        """The sdist carries its pins so it does not need uv or the workspace."""
+        sdist = _single(built_distributions, 'mcp_proxy_for_aws_cli-*.tar.gz')
+        with tarfile.open(sdist) as archive:
+            names = archive.getnames()
+
+        assert any(n.endswith('/_runtime_pins.txt') for n in names)
+
+
+class TestBuildFromSdist:
+    """The wrapper must produce identical pinned metadata when built from its sdist."""
+
+    def test_wheel_built_from_sdist_without_uv_has_identical_pins(
+        self, built_distributions: Path, tmp_path: Path
+    ) -> None:
+        """Rebuild from the sdist in isolation, with `uv` absent from the build's PATH.
+
+        This exercises the baked-pins path: no workspace above the project and no uv to
+        export from, which is how a from-sdist install would build the wrapper.
+        """
+        sdist = _single(built_distributions, 'mcp_proxy_for_aws_cli-*.tar.gz')
+        expected = _requires_dist(_single(built_distributions, 'mcp_proxy_for_aws_cli-*.whl'))
+
+        extracted = tmp_path / 'src'
+        with tarfile.open(sdist) as archive:
+            archive.extractall(extracted)  # noqa: S202 - our own freshly built artifact
+        project = _single(extracted, 'mcp_proxy_for_aws_cli-*')
+
+        uv = shutil.which('uv')
+        assert uv, 'uv is required to run this test'
+        # A PATH without uv, so a regression that ignores the baked pins cannot pass by
+        # silently falling back to `uv export`.
+        sandbox_bin = tmp_path / 'bin'
+        sandbox_bin.mkdir()
+        for tool in ('python3', 'sh'):
+            if (found := shutil.which(tool)) is not None:
+                (sandbox_bin / tool).symlink_to(found)
+
+        out = tmp_path / 'out'
+        result = subprocess.run(
+            [uv, 'build', '--wheel', '--out-dir', str(out), '.'],
+            cwd=project,
+            capture_output=True,
+            text=True,
+            env={'PATH': str(sandbox_bin), 'HOME': str(tmp_path)},
+        )
+        if result.returncode != 0:
+            pytest.fail(f'from-sdist build failed:\n{result.stdout}\n{result.stderr}')
+
+        assert _requires_dist(_single(out, '*.whl')) == expected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,15 @@ update_changelog_on_bump = true
 [tool.hatch.build.targets.wheel]
 packages = ["mcp_proxy_for_aws"]
 
+# The code package's sdist otherwise bundles the whole working tree. Keep the
+# sibling wrapper project (packages/proxy) and local planning notes (.agents)
+# out of it.
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "packages",
+    ".agents",
+]
+
 [tool.bandit]
 exclude_dirs = ["venv", ".venv", "tests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,29 @@
-[tool.uv]
-exclude-newer = "P3D"
-prerelease = "allow"
+# NOTE: there is deliberately no `[tool.uv]` table here.
+#
+# It previously held `exclude-newer = "P3D"` and `prerelease = "allow"`, and both were
+# inert: `exclude-newer` only accepts a fixed date, so `"P3D"` failed to parse and uv
+# discarded the *whole* table along with it -- including the `prerelease` setting.
+#
+# Neither should come back:
+#   * The supply-chain cooldown now lives in `.github/dependabot.yml` (`cooldown`), which
+#     can express a rolling window.
+#   * Allowing pre-releases must stay off. `packages/proxy` pins this project's exact
+#     runtime closure, and a pinned pre-release makes that wrapper uninstallable without
+#     `--prerelease=allow`, which `uvx`/`pip` users cannot pass. The build hook enforces
+#     this, so re-enabling the setting turns a pre-release in the lock into a failed
+#     release. Dependencies that only publish pre-releases (the `agent-framework*` example
+#     tree) still resolve without it, because their own constraints demand them.
 
 [tool.uv.workspace]
 members = [
     "examples/mcp-client/*"
+]
+# The pinned wrapper (packages/proxy) is deliberately NOT a workspace member. Its
+# dependencies are dynamic and derived from this workspace's lock file at build time, so
+# including it would make `uv lock` build the wrapper's metadata from the very lock file
+# it is trying to write. See packages/proxy/hatch_build.py.
+exclude = [
+    "packages/proxy"
 ]
 
 [project]
@@ -40,9 +59,9 @@ classifiers = [
 ]
 
 [project.urls]
-documentation = "https://github.com/aws/aws-mcp-proxy/blob/main/README.md"
+documentation = "https://github.com/aws/mcp-proxy-for-aws/blob/main/README.md"
 repository = "https://github.com/aws/mcp-proxy-for-aws.git"
-changelog = "https://github.com/aws/aws-mcp-proxy/blob/main/CHANGELOG.md"
+changelog = "https://github.com/aws/mcp-proxy-for-aws/blob/main/CHANGELOG.md"
 
 [project.scripts]
 "mcp-proxy-for-aws" = "mcp_proxy_for_aws.server:main"
@@ -50,6 +69,11 @@ changelog = "https://github.com/aws/aws-mcp-proxy/blob/main/CHANGELOG.md"
 [dependency-groups]
 dev = [
     "commitizen>=4.2.2",
+    # Build backend, needed in the dev environment to unit-test packages/proxy's
+    # build hooks (which import hatchling's plugin interfaces).
+    "hatchling>=1.27.0",
+    # tomllib backport, for tests that read pyproject.toml on Python 3.10.
+    "tomli>=2.0.0; python_full_version < '3.11'",
     "pre-commit>=4.1.0",
     "ruff>=0.9.7",
     "pyright>=1.1.398",
@@ -112,9 +136,15 @@ exclude = ["**/__pycache__", "**/.venv", "**/node_modules", "**/dist", "**/build
 name = "cz_conventional_commits"
 version_provider = "uv"
 tag_format = "v$version"
+# The pinned wrapper `mcp-proxy-for-aws-cli` must move in lockstep: its metadata pins
+# `mcp-proxy-for-aws` to its own version, so a wrapper left behind at the previous version
+# would pin a release that this bump has just superseded. A unit test asserts they match.
+#
+# `mcp_proxy_for_aws/__init__.py` is deliberately absent: `__version__` now reads the
+# installed distribution's metadata instead of carrying a literal to rewrite.
 version_files = [
     "pyproject.toml:version",
-    "mcp_proxy_for_aws/__init__.py:__version__"
+    "packages/proxy/pyproject.toml:version"
 ]
 update_changelog_on_bump = true
 
@@ -130,7 +160,7 @@ log_cli_level = "INFO"
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-testpaths = [ "tests"]
+testpaths = [ "tests", "packages/proxy/tests"]
 asyncio_mode = "auto"
 markers = [
     "live: marks tests that make live API calls (deselect with '-m \"not live\"')",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 # NOTE: there is deliberately no `[tool.uv]` table here.
 #
-# It previously held `exclude-newer = "P3D"` and `prerelease = "allow"`, and both were
-# inert: `exclude-newer` only accepts a fixed date, so `"P3D"` failed to parse and uv
-# discarded the *whole* table along with it -- including the `prerelease` setting.
-#
-# Neither should come back:
-#   * The supply-chain cooldown now lives in `.github/dependabot.yml` (`cooldown`), which
-#     can express a rolling window.
+# It previously held `exclude-newer = "P3D"` and `prerelease = "allow"`. Neither should
+# come back:
+#   * The supply-chain cooldown is configured in `.github/dependabot.yml` (`cooldown`).
+#     Recent uv can also express a rolling window here, via `exclude-newer` with a
+#     duration (e.g. "P3D" / "3 days"). We keep it in Dependabot instead because older uv
+#     only accepts a fixed RFC 3339 date and, on seeing a duration, silently drops this
+#     whole table (a warning, then it keeps going) -- and the repo pins no uv version --
+#     so a contributor on an older uv would quietly lose these settings.
 #   * Allowing pre-releases must stay off. `packages/proxy` pins this project's exact
 #     runtime closure, and a pinned pre-release makes that wrapper uninstallable without
 #     `--prerelease=allow`, which `uvx`/`pip` users cannot pass. The build hook enforces

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -8,11 +8,6 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
-
-[options]
-prerelease-mode = "allow"
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P3D"
 
 [manifest]
 members = [
@@ -373,8 +368,8 @@ name = "agent-framework-github-copilot"
 version = "1.0.0rc1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "agent-framework-core" },
-    { name = "github-copilot-sdk" },
+    { name = "agent-framework-core", marker = "python_full_version >= '3.11'" },
+    { name = "github-copilot-sdk", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/b0/7aee4d36674f65c1a854b36cf58a610f498546eb6665982d77325151f442/agent_framework_github_copilot-1.0.0rc1.tar.gz", hash = "sha256:99a62a205a5ee187cffb00912981d4afe3825b0f8f28ed2781dd12a18e633750", size = 12614, upload-time = "2026-06-04T23:55:55.81Z" }
 wheels = [
@@ -386,10 +381,10 @@ name = "agent-framework-hyperlight"
 version = "1.0.0b260507"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "agent-framework-core" },
-    { name = "hyperlight-sandbox" },
-    { name = "hyperlight-sandbox-backend-wasm" },
-    { name = "hyperlight-sandbox-python-guest" },
+    { name = "agent-framework-core", marker = "python_full_version < '3.14'" },
+    { name = "hyperlight-sandbox", marker = "python_full_version < '3.14'" },
+    { name = "hyperlight-sandbox-backend-wasm", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "hyperlight-sandbox-python-guest", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/1f/52a2541d4a0bc5657ca9c2ef4f85885fb323682052da3fc1451eabafb73d/agent_framework_hyperlight-1.0.0b260507.tar.gz", hash = "sha256:845baab7439ac7b94ee53805cf3d32d0eea3b77a040d0f1b367f0a395fd8c08b", size = 19057, upload-time = "2026-05-08T00:09:56.056Z" }
 wheels = [
@@ -1438,7 +1433,7 @@ name = "clr-loader"
 version = "0.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/54/c2/da52aaf19424e3f0abec003d08dd1ccae52c88a3b41e31151a03bed18488/clr_loader-0.2.9.tar.gz", hash = "sha256:6af3d582c3de55ce9e9e676d2b3dbf6bc680c4ea8f76c58786739a5bdcf6b52d", size = 84829, upload-time = "2025-12-05T16:57:12.466Z" }
 wheels = [
@@ -1641,18 +1636,19 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "5.0.0a1"
+version = "4.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "docstring-parser" },
     { name = "rich" },
+    { name = "rich-rst" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/ca/65e020717410cff8916bae89d5b1704ee190d2a345f47ba5e5f903b41d59/cyclopts-5.0.0a1.tar.gz", hash = "sha256:ae24ce6c0c8dbaba3fdfccdb54d2a9d6e2a6270c47ffe101af1de89ff617851a", size = 148291, upload-time = "2025-11-02T19:32:43.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/56/2768e4ce655cdc49d734401c3802f0ce6aff84d9693069df0678550a58d8/cyclopts-4.23.1.tar.gz", hash = "sha256:ec8e776bf62f78d705766333ab8621a21ec0e40cd1af3f96f362231a3df4528a", size = 196113, upload-time = "2026-08-20T20:10:18.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d3/eda07755dffa4ea637a673181934bcd54255def1c71dd1cc0f8ec49f888e/cyclopts-5.0.0a1-py3-none-any.whl", hash = "sha256:731e0c4412d47993202abffd0bfe222353b12347dfef7e874ac769c74c8a162a", size = 183923, upload-time = "2025-11-02T19:32:41.532Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/fe/7a266de66b3fcfcebbde248742c923f0e38aafa59dfa358096c01e34a62a/cyclopts-4.23.1-py3-none-any.whl", hash = "sha256:08827bd4273eb70eb814810dd493b800ff38629fe904f2051d8b48904d0754ff", size = 236157, upload-time = "2026-08-20T20:10:16.55Z" },
 ]
 
 [[package]]
@@ -2063,8 +2059,8 @@ name = "github-copilot-sdk"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "python-dateutil" },
+    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/2c/3d3ecfe500c0ba7d3127737b1aa22f19ff1a19e6e86360bfdca3f02a2c09/github_copilot_sdk-1.0.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:856dfc8370f36f6efd8a2aa1dd40f82c1a6d0573d0577eaff1f6affb73ed29ad", size = 97329153, upload-time = "2026-06-18T00:56:20.653Z" },
@@ -2302,6 +2298,23 @@ wheels = [
 ]
 
 [[package]]
+name = "hatchling"
+version = "1.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomlkit" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/08/33331757185504aae48b8d9bd78cec03a76e3aecfb52e549d05a2347c0dd/hatchling-1.32.0.tar.gz", hash = "sha256:0bdbde4a52b06c37e3eca395f85a762bf0ef06fe374fd8ae429dc6be10230f5f", size = 57783, upload-time = "2026-08-11T05:03:44.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/84/1798b6d85ecde0e31546004efd25c5de1b1f49250644a60cce460e12593a/hatchling-1.32.0-py3-none-any.whl", hash = "sha256:0e17c9c3b9aa7c625acc8d0f5b622f107d5049af9ecf5ada4de1aada5be7cdbc", size = 78435, upload-time = "2026-08-11T05:03:42.644Z" },
+]
+
+[[package]]
 name = "hpack"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2479,7 +2492,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -2756,17 +2769,17 @@ wheels = [
 
 [[package]]
 name = "jsonschema-path"
-version = "0.4.0b1"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "attrs" },
     { name = "pathable" },
-    { name = "pyrsistent" },
     { name = "pyyaml" },
     { name = "referencing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/b9/eb99f1367ebcf8d6e2ae4f1c6e3da61eeb0ddd11c2695b1cdad8a9dad631/jsonschema_path-0.4.0b1.tar.gz", hash = "sha256:4678dcb27e5fbc58b39baf7ca8c36a6a7de3bcafacaaafc1b8a1d54038ce8d8a", size = 11807, upload-time = "2025-06-07T20:52:58.9Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/79/cd02a4df6d9270efdc7d3feefe6edd730b0820c39eeaa107a2faee8322d5/jsonschema_path-0.5.0.tar.gz", hash = "sha256:493b156ba895c97602655b620a8456caa2ce08c1aa389f5a7addec065e6e855c", size = 19597, upload-time = "2026-05-19T20:45:00.971Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/f5/24d5b91ed0409989140d1d4217e9c852d81782ced54e46b0582ad5f56dcb/jsonschema_path-0.4.0b1-py3-none-any.whl", hash = "sha256:f0cd42238c1445cecac3b2796fa24dcc62b8426623d1cb4d8d755f3715abf3ba", size = 15293, upload-time = "2025-06-07T20:52:57.029Z" },
+    { url = "https://files.pythonhosted.org/packages/04/2c/9e69d73c4297508be9e3b64a970ea3971b3eb8db64ffc5802d40bd25981f/jsonschema_path-0.5.0-py3-none-any.whl", hash = "sha256:2790a070bc7abb08ea3dbe4d340ece4efadf639223001f020c7503229ba068e2", size = 24077, upload-time = "2026-05-19T20:44:59.225Z" },
 ]
 
 [[package]]
@@ -3299,6 +3312,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "commitizen" },
+    { name = "hatchling" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
@@ -3306,6 +3320,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
@@ -3318,6 +3333,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "commitizen", specifier = ">=4.2.2" },
+    { name = "hatchling", specifier = ">=1.27.0" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pyright", specifier = ">=1.1.398" },
     { name = "pytest", specifier = ">=8.0.0" },
@@ -3325,6 +3341,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.12.0" },
     { name = "ruff", specifier = ">=0.9.7" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]
 
 [[package]]
@@ -4566,14 +4583,20 @@ wheels = [
 
 [[package]]
 name = "pathable"
-version = "0.5.0b2"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyrsistent" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/a0/5ce545bf5d14d3b8925e73f12f67adee7a139a6726c0df75aca25ab6e8b7/pathable-0.5.0b2.tar.gz", hash = "sha256:0005483148dc1991ab32e4cb4cde7e2b8f376f081a1639631e424db0792860e9", size = 9896, upload-time = "2025-06-07T20:45:35.764Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/9a/8a74be1ab54bb62bd3c1554af8ef431c530f843d713785874207a77229e6/pathable-0.5.0b2-py3-none-any.whl", hash = "sha256:4c78bc5dae0c64a6191b955b7975bab58f0e298e197f591d4f0172886824a52b", size = 11374, upload-time = "2025-06-07T20:45:34.114Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -4710,8 +4733,8 @@ name = "powerfx"
 version = "0.0.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
-    { name = "pythonnet" },
+    { name = "cffi", marker = "python_full_version < '3.14'" },
+    { name = "pythonnet", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/41/8f95f72f4f3b7ea54357c449bf5bd94813b6321dec31db9ffcbf578e2fa3/powerfx-0.0.33.tar.gz", hash = "sha256:85e8330bef8a7a207c3e010aa232df0ae38825e94d590c73daf3a3f44115cb09", size = 3236647, upload-time = "2025-11-20T19:31:09.414Z" }
 wheels = [
@@ -5319,33 +5342,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyrsistent"
-version = "0.20.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/3a/5031723c09068e9c8c2f0bc25c3a9245f2b1d1aea8396c787a408f2b95ca/pyrsistent-0.20.0.tar.gz", hash = "sha256:4c48f78f62ab596c679086084d0dd13254ae4f3d6c72a83ffdf5ebdef8f265a4", size = 103642, upload-time = "2023-10-25T21:06:56.342Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/19/c343b14061907b629b765444b6436b160e2bd4184d17d4804bbe6381f6be/pyrsistent-0.20.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8c3aba3e01235221e5b229a6c05f585f344734bd1ad42a8ac51493d74722bbce", size = 83416, upload-time = "2023-10-25T21:06:04.579Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/4f/8342079ea331031ef9ed57edd312a9ad283bcc8adfaf268931ae356a09a6/pyrsistent-0.20.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1beb78af5423b879edaf23c5591ff292cf7c33979734c99aa66d5914ead880f", size = 118021, upload-time = "2023-10-25T21:06:06.953Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/b7/64a125c488243965b7c5118352e47c6f89df95b4ac306d31cee409153d57/pyrsistent-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21cc459636983764e692b9eba7144cdd54fdec23ccdb1e8ba392a63666c60c34", size = 117747, upload-time = "2023-10-25T21:06:08.5Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/a5/43c67bd5f80df9e7583042398d12113263ec57f27c0607abe9d78395d18f/pyrsistent-0.20.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f5ac696f02b3fc01a710427585c855f65cd9c640e14f52abe52020722bb4906b", size = 114524, upload-time = "2023-10-25T21:06:10.728Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/98/b382a87e89ca839106d874f7bf78d226b3eedb26735eb6f751f1a3375f21/pyrsistent-0.20.0-cp310-cp310-win32.whl", hash = "sha256:0724c506cd8b63c69c7f883cc233aac948c1ea946ea95996ad8b1380c25e1d3f", size = 60780, upload-time = "2023-10-25T21:06:12.14Z" },
-    { url = "https://files.pythonhosted.org/packages/37/8a/23e2193f7adea6901262e3cf39c7fe18ac0c446176c0ff0e19aeb2e9681e/pyrsistent-0.20.0-cp310-cp310-win_amd64.whl", hash = "sha256:8441cf9616d642c475684d6cf2520dd24812e996ba9af15e606df5f6fd9d04a7", size = 63310, upload-time = "2023-10-25T21:06:13.598Z" },
-    { url = "https://files.pythonhosted.org/packages/df/63/7544dc7d0953294882a5c587fb1b10a26e0c23d9b92281a14c2514bac1f7/pyrsistent-0.20.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0f3b1bcaa1f0629c978b355a7c37acd58907390149b7311b5db1b37648eb6958", size = 83481, upload-time = "2023-10-25T21:06:15.238Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/a0/49249bc14d71b1bf2ffe89703acfa86f2017c25cfdabcaea532b8c8a5810/pyrsistent-0.20.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cdd7ef1ea7a491ae70d826b6cc64868de09a1d5ff9ef8d574250d0940e275b8", size = 120222, upload-time = "2023-10-25T21:06:17.144Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/94/9808e8c9271424120289b9028a657da336ad7e43da0647f62e4f6011d19b/pyrsistent-0.20.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cae40a9e3ce178415040a0383f00e8d68b569e97f31928a3a8ad37e3fde6df6a", size = 120002, upload-time = "2023-10-25T21:06:18.727Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/f6/9ecfb78b2fc8e2540546db0fe19df1fae0f56664a5958c21ff8861b0f8da/pyrsistent-0.20.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6288b3fa6622ad8a91e6eb759cfc48ff3089e7c17fb1d4c59a919769314af224", size = 116850, upload-time = "2023-10-25T21:06:20.424Z" },
-    { url = "https://files.pythonhosted.org/packages/83/c8/e6d28bc27a0719f8eaae660357df9757d6e9ca9be2691595721de9e8adfc/pyrsistent-0.20.0-cp311-cp311-win32.whl", hash = "sha256:7d29c23bdf6e5438c755b941cef867ec2a4a172ceb9f50553b6ed70d50dfd656", size = 60775, upload-time = "2023-10-25T21:06:21.815Z" },
-    { url = "https://files.pythonhosted.org/packages/98/87/c6ef52ff30388f357922d08de012abdd3dc61e09311d88967bdae23ab657/pyrsistent-0.20.0-cp311-cp311-win_amd64.whl", hash = "sha256:59a89bccd615551391f3237e00006a26bcf98a4d18623a19909a2c48b8e986ee", size = 63306, upload-time = "2023-10-25T21:06:22.874Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ee/ff2ed52032ac1ce2e7ba19e79bd5b05d152ebfb77956cf08fcd6e8d760ea/pyrsistent-0.20.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:09848306523a3aba463c4b49493a760e7a6ca52e4826aa100ee99d8d39b7ad1e", size = 83537, upload-time = "2023-10-25T21:06:24.17Z" },
-    { url = "https://files.pythonhosted.org/packages/80/f1/338d0050b24c3132bcfc79b68c3a5f54bce3d213ecef74d37e988b971d8a/pyrsistent-0.20.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a14798c3005ec892bbada26485c2eea3b54109cb2533713e355c806891f63c5e", size = 122615, upload-time = "2023-10-25T21:06:25.815Z" },
-    { url = "https://files.pythonhosted.org/packages/07/3a/e56d6431b713518094fae6ff833a04a6f49ad0fbe25fb7c0dc7408e19d20/pyrsistent-0.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b14decb628fac50db5e02ee5a35a9c0772d20277824cfe845c8a8b717c15daa3", size = 122335, upload-time = "2023-10-25T21:06:28.631Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/bb/5f40a4d5e985a43b43f607250e766cdec28904682c3505eb0bd343a4b7db/pyrsistent-0.20.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e2c116cc804d9b09ce9814d17df5edf1df0c624aba3b43bc1ad90411487036d", size = 118510, upload-time = "2023-10-25T21:06:30.718Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/13/e6a22f40f5800af116c02c28e29f15c06aa41cb2036f6a64ab124647f28b/pyrsistent-0.20.0-cp312-cp312-win32.whl", hash = "sha256:e78d0c7c1e99a4a45c99143900ea0546025e41bb59ebc10182e947cf1ece9174", size = 60865, upload-time = "2023-10-25T21:06:32.742Z" },
-    { url = "https://files.pythonhosted.org/packages/75/ef/2fa3b55023ec07c22682c957808f9a41836da4cd006b5f55ec76bf0fbfa6/pyrsistent-0.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:4021a7f963d88ccd15b523787d18ed5e5269ce57aa4037146a2377ff607ae87d", size = 63239, upload-time = "2023-10-25T21:06:34.035Z" },
-    { url = "https://files.pythonhosted.org/packages/23/88/0acd180010aaed4987c85700b7cc17f9505f3edb4e5873e4dc67f613e338/pyrsistent-0.20.0-py3-none-any.whl", hash = "sha256:c55acc4733aad6560a7f5f818466631f07efc001fd023f34a6c203f8b6df0f0b", size = 58106, upload-time = "2023-10-25T21:06:54.387Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5447,7 +5443,7 @@ name = "pythonnet"
 version = "3.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "clr-loader" },
+    { name = "clr-loader", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/d6/1afd75edd932306ae9bd2c2d961d603dc2b52fcec51b04afea464f1f6646/pythonnet-3.0.5.tar.gz", hash = "sha256:48e43ca463941b3608b32b4e236db92d8d40db4c58a75ace902985f76dac21cf", size = 239212, upload-time = "2024-12-13T08:30:44.393Z" }
 wheels = [
@@ -5796,6 +5792,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/d6/d0b9fafc73b65767200da027acab1db1bdb1048f4fea5ebf659df01c700e/rich_rst-2.1.0.tar.gz", hash = "sha256:f4d117b49697f338769759fa5cacf5197da4888b347b9fda2e50aef5cd8d93bd", size = 302732, upload-time = "2026-07-05T02:59:44.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/68/1fc93dd759605b5d00fc98b50200739e41ed32bd22d6ba35ca6c3932371b/rich_rst-2.1.0-py3-none-any.whl", hash = "sha256:7ecd1343ee12c879d0e7ae74c3eb6d263b023d2929c6d114212eb1fd91057255", size = 272987, upload-time = "2026-07-05T02:59:42.792Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6103,8 +6112,8 @@ name = "taskgroup"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup" },
-    { name = "typing-extensions" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
 wheels = [
@@ -6267,6 +6276,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2026.6.1.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz", hash = "sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745", size = 17059, upload-time = "2026-06-01T19:41:34.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl", hash = "sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3", size = 14211, upload-time = "2026-06-01T19:41:33.434Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Publish two distributions from one codebase so CLI users get a frozen dependency tree without constraining library users:

- `mcp-proxy-for-aws` keeps the code and loose, co-resolvable dependency ranges for programmatic/library use. The import name `mcp_proxy_for_aws` and the `mcp-proxy-for-aws` console script are unchanged.
- `mcp-proxy-for-aws-cli` is a new, metadata-only wrapper for CLI/`uvx` use. Its exact runtime closure (plus `mcp-proxy-for-aws==<version>`) is derived from uv.lock at build time by a Hatchling metadata hook and baked into the published wheel, so a fresh install gets a frozen tree and cannot silently adopt a newer release of a transitive dependency.

The wrapper is excluded from the uv workspace so `uv lock` never builds its dynamic metadata from the lock it is writing. A build-time guard fails the release if the closure contains a pre-release (which uvx/pip users cannot install without --prerelease=allow). Publish workflows build the wrapper by path and publish the code package before the wrapper that pins it; the Dockerfile installs mcp-proxy-for-aws-cli; the READMEs document which distribution to use. python.yml also gains a merge_group trigger so the required Build check runs for queued merges.

This is version-pinning, not hash-verification: it prevents auto-adoption of a newer compromised release; it does not cryptographically verify installed artifacts.

## Summary

### Changes

> Please provide a summary of what's being changed

Publishes two distributions from this one codebase so CLI users get a frozen dependency tree without constraining library users:
- **`mcp-proxy-for-aws`** — unchanged: keeps the code and its loose, co-resolvable dependency ranges. The import name `mcp_proxy_for_aws` and the `mcp-proxy-for-aws` console script are the same, so existing installs and programmatic users are unaffected.
- **`mcp-proxy-for-aws-cli`** — new, metadata-only wrapper for CLI/`uvx` use. Its exact `==` runtime closure (plus `mcp-proxy-for-aws==<version>`) is derived from `uv.lock` at build time by a Hatchling metadata hook and baked into the  published wheel, so a fresh install gets a frozen tree and cannot silently adopt a newer release of a transitive dependency
 
Implementation notes:
-  The wrapper is excluded from the uv workspace so `uv lock` never builds its dynamic metadata from the lock file it is writing.
- A build-time guard fails the release if the pinned closure contains a pre-release (uninstallable via `uvx`/`pip` without `--prerelease=allow`).
- Publish workflows build the wrapper by path and publish the code package **before** the wrapper that pins it by exact version; the Dockerfile installs `mcp-proxy-for-aws-cli`.
- `python.yml` gains a `merge_group` trigger so the required Build check runs for merge-queue entries.
- READMEs document which distribution to install for CLI vs. library use

### User experience

> Please share what the user experience looks like before and after this change

**Before**
`uvx mcp-proxy-for-aws@<version>` pins only the proxy's own version. Its transitive dependencies are loose ranges, so every cold install resolves the whole tree to whatever is newest on PyPI — a newer, possibly compromised release
  of a dependency is adopted automatically.
  
**After**
 - **CLI / `uvx` users** install the pinned distribution and get a frozen tree:
   uvx mcp-proxy-for-aws-cli@<version> <SigV4 MCP endpoint URL>
  "args": ["mcp-proxy-for-aws-cli@<version>", "https://aws-mcp.us-east-1.api.aws/mcp"]
  
- Library users are unchanged:  same install, same import, same loose ranges so it co-resolves with their own dependencies:
  pip install mcp-proxy-for-aws
  from mcp_proxy_for_aws.client import aws_iam_streamablehttp_client
  
- Existing mcp-proxy-for-aws installs keep working and upgrade normally. That distribution still owns the code and the mcp-proxy-for-aws command, so a  pip install --upgrade is an same-distribution upgrade 
  


The README points CLI/uvx users at mcp-proxy-for-aws-cli and library users at mcp-proxy-for-aws, so new setups and reconfigurations pick the right one.


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [X] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
