### PR TITLE
fix: replace call_aws tests with run_script

### DIFF
--- a/tests/integ/test_aws_mcp_server_happy_path.py
+++ b/tests/integ/test_aws_mcp_server_happy_path.py
@@ -87,11 +87,11 @@ def verify_json_response(response: CallToolResult):
     'tool_name,params',
     [
         ('aws___list_regions', {}),
-        ('aws___call_aws', {'cli_command': 'aws lambda list-functions', 'max_results': 10}),
+        ('aws___run_script', {'code': 'result = {"ok": True}\nresult'}),
     ],
     ids=[
         'list_regions',
-        'list_lambda_functions',
+        'run_script',
     ],
 )
 @pytest.mark.asyncio(loop_scope='module')

--- a/tests/integ/test_aws_mcp_server_negative.py
+++ b/tests/integ/test_aws_mcp_server_negative.py
@@ -67,7 +67,7 @@ async def test_expired_credentials():
 
     try:
         async with expired_client:
-            response = await expired_client.call_tool('aws___call_aws')
+            response = await expired_client.call_tool('aws___run_script')
             logger.info('Tool call completed without exception. Response: %s', response)
     except Exception as e:
         exception_raised = True


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

* [ ] Yes
* [ ] No

Please add details about how this change was tested.

- [ ] Did integration tests succeed?
- [ ] If the feature is a new use case, is it necessary to add a new integration test case?


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
