### PR TITLE
fix: report non-2xx upstream responses to library mode callers

### DIFF
--- a/mcp_proxy_for_aws/client.py
+++ b/mcp_proxy_for_aws/client.py
@@ -23,6 +23,7 @@ from functools import partial
 from mcp.client.streamable_http import GetSessionIdCallback, streamable_http_client
 from mcp.shared._httpx_utils import McpHttpClientFactory, create_mcp_http_client
 from mcp.shared.message import SessionMessage
+from mcp_proxy_for_aws.mcp1_compat import _translate_http_error_hook
 from mcp_proxy_for_aws.sigv4_helper import SigV4HTTPXAuth, _inject_metadata_hook
 from mcp_proxy_for_aws.utils import validate_endpoint_url
 
@@ -128,6 +129,9 @@ def aws_iam_streamablehttp_client(
         timeout.total_seconds() if isinstance(timeout, timedelta) else timeout
     )
     http_client = httpx_client_factory(headers=headers, timeout=httpx_timeout, auth=auth)
+
+    # Temporary mcp 1.x plumbing, see mcp_proxy_for_aws.mcp1_compat. Remove with that module.
+    http_client.event_hooks.setdefault('response', []).append(_translate_http_error_hook)
 
     # Append metadata injection hook if metadata is provided
     if metadata:

--- a/mcp_proxy_for_aws/mcp1_compat.py
+++ b/mcp_proxy_for_aws/mcp1_compat.py
@@ -1,0 +1,138 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Non-2xx handling that mcp 1.x lacks. Delete this module after the move to mcp 2.x.
+
+mcp 1.x calls ``raise_for_status()`` on a POST reply from inside the task it spawned for that
+request (``mcp/client/streamable_http.py``), so a non-2xx tears the transport down instead of
+answering the request. The caller stays parked in ``BaseSession.send_request``, which waits
+without a timeout by default, and a session held on a background event loop, the shape agent
+frameworks use, never recovers: the cancellation that should close the read stream also aborts
+the receive loop before it can hand pending requests their error.
+
+mcp 2.x answers the request id itself (``if response.status_code >= 400`` in the same file), so
+this module is only needed while the dependency chain caps mcp below 2.0: today
+``fastmcp>=3.2,<3.5`` -> ``fastmcp-slim`` -> ``mcp<2.0``. There is no fastmcp 3.5, so mcp 2.x
+arrives with fastmcp 4.0. Delete this module, ``tests/unit/test_mcp1_compat.py``, and the hook
+registration in ``client.py`` on that upgrade; none of the three survive it quietly, because
+2.x turns ``JSONRPCMessage`` into a union alias that cannot be constructed.
+
+Only the library path uses this. The proxy path needs to keep seeing ``httpx.HTTPStatusError``,
+which both ``ToolErrorMiddleware`` and ``AWSMCPProxyClient._connect`` inspect.
+"""
+
+import httpx
+import json
+import logging
+from mcp.types import ErrorData, JSONRPCError, JSONRPCMessage
+
+
+logger = logging.getLogger(__name__)
+
+_MAX_BODY_CHARS = 500
+
+
+async def _translate_http_error_hook(response: httpx.Response) -> None:
+    """Answer a failed POST with a JSON-RPC error keyed to the id the caller waits on.
+
+    Rewriting the reply in place keeps the failure on the JSON-RPC channel: the transport reads
+    a well formed error response, routes it to the pending request, and the caller gets an
+    ``McpError`` naming the HTTP status while the session stays usable.
+    """
+    if not _is_unreported_failure(response):
+        return
+
+    message = _outgoing_jsonrpc_message(response.request)
+    if message is None:
+        return
+
+    detail = await _read_failure_detail(response)
+
+    request_id = message.get('id')
+    if isinstance(request_id, (int, str)):
+        _answer_pending_request(response, request_id, detail)
+    else:
+        _accept_failed_notification(response, message.get('method'), detail)
+
+
+def _is_unreported_failure(response: httpx.Response) -> bool:
+    """Report whether this is a failure the transport will not tell the caller about itself."""
+    if response.request.method != 'POST':
+        # GET (SSE) and DELETE (termination) failures are already contained by the transport.
+        return False
+
+    if response.status_code < 400:
+        # 3xx is left alone: the default client follows redirects, and this hook runs first.
+        return False
+
+    # The transport reports a dropped session itself.
+    return response.status_code != 404
+
+
+def _outgoing_jsonrpc_message(request: httpx.Request) -> dict | None:
+    """Parse the JSON-RPC message a request carries, or None if it does not look like one."""
+    try:
+        message = json.loads(request.content)
+    except Exception as e:
+        logger.debug('Request body is not JSON: %s', e)
+        return None
+
+    if isinstance(message, dict) and 'jsonrpc' in message:
+        return message
+
+    logger.debug('Request body is not a single JSON-RPC message')
+    return None
+
+
+async def _read_failure_detail(response: httpx.Response) -> str:
+    """Read what the endpoint said about the failure, capped at a length safe to pass on."""
+    try:
+        body = await response.aread()
+    except Exception as e:
+        logger.debug('Could not read body of HTTP %d response: %s', response.status_code, e)
+        return ''
+
+    detail = body.decode('utf-8', errors='replace').strip()
+    if len(detail) > _MAX_BODY_CHARS:
+        return f'{detail[:_MAX_BODY_CHARS]}... (truncated)'
+    return detail
+
+
+def _answer_pending_request(response: httpx.Response, request_id: int | str, detail: str) -> None:
+    """Turn the reply into the JSON-RPC error response the waiting request needs."""
+    text = f'HTTP {response.status_code} {response.reason_phrase} from {response.url}'
+    if detail:
+        text = f'{text}: {detail}'
+
+    logger.warning('%s. Reporting it to the caller as a JSON-RPC error.', text)
+
+    error = JSONRPCError(
+        jsonrpc='2.0', id=request_id, error=ErrorData(code=response.status_code, message=text)
+    )
+
+    response._content = (
+        JSONRPCMessage(error).model_dump_json(by_alias=True, exclude_none=True).encode()
+    )
+    response.status_code = 200
+    response.headers['content-type'] = 'application/json'
+
+
+def _accept_failed_notification(response: httpx.Response, method: str | None, detail: str) -> None:
+    """Report a failed notification as accepted, since nothing is waiting on a reply.
+
+    The alternative is raise_for_status taking the whole transport down over a message that
+    has no response.
+    """
+    logger.warning('HTTP %d for notification %r: %s', response.status_code, method, detail)
+    response.status_code = 202

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ readme = "README.md"
 requires-python = ">=3.10,<3.15"
 dependencies = [
     "fastmcp>=3.2,<3.5",
+    # Used directly for SigV4 signing, request hooks and error handling, so it is declared
+    # rather than relied on transitively through fastmcp -> mcp. The cap matches mcp's own.
+    "httpx>=0.27.1,<1.0",
     "boto3>=1.41.0",
     "botocore[crt]>=1.41.0",
 ]

--- a/tests/integ/test_library_client.py
+++ b/tests/integ/test_library_client.py
@@ -1,0 +1,102 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for programmatic access against a remote MCP server.
+
+The other integration tests drive the proxy path through `StdioTransport`. These cover the
+library path, `aws_iam_streamablehttp_client`, which agent frameworks embed directly and which
+therefore has no proxy middleware in front of it.
+"""
+
+import asyncio
+import logging
+import os
+import pytest
+from botocore.credentials import Credentials
+from mcp import ClientSession, McpError
+from mcp_proxy_for_aws.client import aws_iam_streamablehttp_client
+from mcp_proxy_for_aws.utils import get_service_name_and_region_from_endpoint
+from tests.integ.conftest import RemoteMCPServerConfiguration
+
+
+logger = logging.getLogger(__name__)
+
+_BUDGET_SECONDS = 60
+
+
+def open_session(configuration: RemoteMCPServerConfiguration, **overrides):
+    """Open a library-path session against the configured remote MCP server."""
+    endpoint = configuration['endpoint']
+    service, _ = get_service_name_and_region_from_endpoint(endpoint)
+
+    return aws_iam_streamablehttp_client(
+        endpoint=endpoint,
+        aws_service=service,
+        aws_region=configuration['region_name'],
+        **overrides,
+    )
+
+
+@pytest.mark.asyncio(loop_scope='module')
+async def test_library_client_completes_an_exchange(
+    remote_mcp_server_configuration: RemoteMCPServerConfiguration,
+):
+    """The library path can reach a real endpoint and list its tools."""
+
+    async def exchange():
+        async with open_session(remote_mcp_server_configuration) as (read_stream, write_stream, _):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                return await session.list_tools()
+
+    result = await asyncio.wait_for(exchange(), timeout=_BUDGET_SECONDS)
+
+    assert len(result.tools) > 0, f'Remote MCP server should have tools, got {result}'
+
+
+@pytest.mark.skipif(
+    not os.environ.get('AGENTCORE_RUNTIME_ARN'),
+    reason='needs an endpoint that verifies SigV4; a local server accepts any signature',
+)
+@pytest.mark.asyncio(loop_scope='module')
+async def test_library_client_reports_http_failure_to_the_caller(
+    remote_mcp_server_configuration: RemoteMCPServerConfiguration,
+):
+    """A real non-2xx reaches the caller as an error instead of leaving the request pending.
+
+    Invalid credentials are used because a rejected signature is the one non-2xx a live
+    endpoint returns deterministically; `tests/unit/test_mcp1_compat.py` covers the reported
+    413 shape, which carries no body and no content type. Without the mcp 1.x workaround the
+    failure raises out of the transport's own task group rather than answering this request,
+    and a caller holding the session on a background event loop waits forever.
+    """
+    unusable = Credentials(access_key='AKIAIOSFODNN7EXAMPLE', secret_key='x' * 40)
+
+    async def exchange():
+        async with open_session(remote_mcp_server_configuration, credentials=unusable) as (
+            read_stream,
+            write_stream,
+            _,
+        ):
+            async with ClientSession(read_stream, write_stream) as session:
+                with pytest.raises(McpError) as rejected:
+                    await session.initialize()
+                return str(rejected.value)
+
+    message = await asyncio.wait_for(exchange(), timeout=_BUDGET_SECONDS)
+
+    logger.info('Endpoint rejected the request with: %s', message)
+    assert 'HTTP 4' in message, (
+        f'Error should name the HTTP status the endpoint returned, got: {message}'
+    )

--- a/tests/unit/test_mcp1_compat.py
+++ b/tests/unit/test_mcp1_compat.py
@@ -1,0 +1,266 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the mcp 1.x non-2xx workaround.
+
+Delete this file together with `mcp_proxy_for_aws.mcp1_compat`. It uses mcp 1.x APIs that
+2.x drops, so it stops importing on the upgrade rather than passing silently.
+"""
+
+import asyncio
+import httpx
+import json
+import pytest
+from botocore.credentials import Credentials
+from mcp import ClientSession, McpError
+from mcp.types import JSONRPCError, JSONRPCMessage
+from mcp_proxy_for_aws.client import aws_iam_streamablehttp_client
+from mcp_proxy_for_aws.mcp1_compat import _translate_http_error_hook
+from mcp_proxy_for_aws.sigv4_helper import create_sigv4_client
+
+
+ENDPOINT = 'https://mcp.example.com/mcp'
+CREDENTIALS = Credentials('test_key', 'test_secret', 'test_token')
+
+TOOLS_CALL = {
+    'jsonrpc': '2.0',
+    'id': 7,
+    'method': 'tools/call',
+    'params': {'name': 'type_text', 'arguments': {'text': 'a'}},
+}
+INITIALIZED_NOTIFICATION = {'jsonrpc': '2.0', 'method': 'notifications/initialized'}
+
+
+def test_proxy_path_does_not_carry_the_workaround():
+    """Keep this off the proxy path, which needs to go on seeing httpx.HTTPStatusError.
+
+    `ToolErrorMiddleware` and `AWSMCPProxyClient._connect` both inspect that exception, so
+    answering the request here instead would replace their messages with a generic one.
+    """
+    proxy_client = create_sigv4_client(service='test-service', region='us-west-2')
+
+    assert _translate_http_error_hook not in proxy_client.event_hooks['response']
+
+
+def build_response(
+    status_code: int,
+    body: bytes = b'',
+    request_body: dict | list | bytes = TOOLS_CALL,
+    method: str = 'POST',
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    """Build a response as httpx hands it to a response hook."""
+    content = (
+        request_body if isinstance(request_body, bytes) else json.dumps(request_body).encode()
+    )
+    request = httpx.Request(method, ENDPOINT, content=content)
+    return httpx.Response(status_code, content=body, headers=headers, request=request)
+
+
+def parse_body(response: httpx.Response) -> JSONRPCError:
+    """Read the response body back as the JSON-RPC error the transport will see."""
+    message = JSONRPCMessage.model_validate_json(response.content).root
+    assert isinstance(message, JSONRPCError)
+    return message
+
+
+async def test_failed_request_becomes_jsonrpc_error_for_the_pending_id():
+    """A rejected tool call is answered on the JSON-RPC channel, keyed to the request id."""
+    # 413 with an empty body and no content type is what a CloudFront WAF returns.
+    response = build_response(413, b'')
+
+    await _translate_http_error_hook(response)
+
+    assert response.status_code == 200
+    assert response.headers['content-type'] == 'application/json'
+    error = parse_body(response)
+    assert error.id == 7
+    assert error.error.code == 413
+    assert 'HTTP 413' in error.error.message
+    assert ENDPOINT in error.error.message
+
+
+async def test_response_body_is_quoted_in_the_error_message():
+    """Whatever the endpoint said about the failure reaches the caller."""
+    response = build_response(500, b'upstream blew up')
+
+    await _translate_http_error_hook(response)
+
+    assert 'upstream blew up' in parse_body(response).error.message
+
+
+async def test_long_response_body_is_truncated():
+    """A large error body cannot be pasted wholesale into the error message."""
+    response = build_response(500, b'x' * 5000)
+
+    await _translate_http_error_hook(response)
+
+    message = parse_body(response).error.message
+    assert '... (truncated)' in message
+    assert len(message) < 1000
+
+
+async def test_unreadable_body_still_produces_an_error():
+    """A body that cannot be read must not stop the caller from being told the status."""
+    response = build_response(502, b'')
+
+    async def failing_aread():
+        raise httpx.ReadError('connection reset while reading the error body')
+
+    response.aread = failing_aread  # type: ignore[method-assign]
+
+    await _translate_http_error_hook(response)
+
+    assert parse_body(response).error.code == 502
+
+
+async def test_failed_notification_is_reported_as_accepted():
+    """Nothing waits on a notification, so the session is kept instead of torn down."""
+    response = build_response(500, b'nope', request_body=INITIALIZED_NOTIFICATION)
+
+    await _translate_http_error_hook(response)
+
+    assert response.status_code == 202
+
+
+@pytest.mark.parametrize(
+    'kwargs',
+    [
+        pytest.param({'status_code': 200, 'body': b'{}'}, id='success'),
+        pytest.param({'status_code': 202}, id='accepted'),
+        pytest.param(
+            {'status_code': 307, 'headers': {'location': 'https://elsewhere.example.com/mcp'}},
+            id='redirect-left-to-httpx',
+        ),
+        pytest.param({'status_code': 404}, id='session-terminated'),
+        pytest.param({'status_code': 405, 'method': 'GET'}, id='get-sse-not-supported'),
+        pytest.param({'status_code': 405, 'method': 'DELETE'}, id='delete-not-supported'),
+        pytest.param({'status_code': 500, 'request_body': b'not json'}, id='unparseable-request'),
+        pytest.param({'status_code': 500, 'request_body': [TOOLS_CALL]}, id='batched-request'),
+    ],
+)
+async def test_responses_left_untouched(kwargs):
+    """Cases the transport already handles are passed through unchanged."""
+    response = build_response(**kwargs)
+    original_status = response.status_code
+    original_body = response.content
+
+    await _translate_http_error_hook(response)
+
+    assert response.status_code == original_status
+    assert response.content == original_body
+
+
+def mock_client_factory(handler):
+    """Build an httpx client factory that serves responses from handler."""
+
+    def factory(headers=None, timeout=None, auth=None, **kwargs):
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), headers=headers, timeout=timeout, auth=auth
+        )
+
+    return factory
+
+
+def mcp_endpoint(oversize_limit: int):
+    """Serve MCP over HTTP, rejecting oversize tool calls the way a WAF does."""
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method != 'POST':
+            # The server supports neither the GET stream nor session termination.
+            return httpx.Response(405)
+
+        message = json.loads(request.content)
+        method = message['method']
+        calls.append(method)
+
+        if method == 'initialize':
+            return httpx.Response(
+                200,
+                json={
+                    'jsonrpc': '2.0',
+                    'id': message['id'],
+                    'result': {
+                        'protocolVersion': '2025-06-18',
+                        'capabilities': {'tools': {}},
+                        'serverInfo': {'name': 'test', 'version': '1.0.0'},
+                    },
+                },
+            )
+        if method.startswith('notifications/'):
+            return httpx.Response(202)
+        if method == 'tools/list':
+            return httpx.Response(
+                200,
+                json={
+                    'jsonrpc': '2.0',
+                    'id': message['id'],
+                    'result': {
+                        'tools': [
+                            {
+                                'name': 'type_text',
+                                'inputSchema': {
+                                    'type': 'object',
+                                    'properties': {'text': {'type': 'string'}},
+                                },
+                            }
+                        ]
+                    },
+                },
+            )
+        if len(request.content) > oversize_limit:
+            return httpx.Response(413)
+        return httpx.Response(
+            200,
+            json={
+                'jsonrpc': '2.0',
+                'id': message['id'],
+                'result': {'content': [{'type': 'text', 'text': 'ok'}], 'isError': False},
+            },
+        )
+
+    return handler, calls
+
+
+async def test_rejected_tool_call_raises_and_leaves_the_session_usable():
+    """The caller is told about the 413 and can keep using the session afterwards."""
+    handler, calls = mcp_endpoint(oversize_limit=2048)
+
+    async def drive():
+        client = aws_iam_streamablehttp_client(
+            endpoint=ENDPOINT,
+            aws_service='bedrock-agentcore',
+            aws_region='us-west-2',
+            credentials=CREDENTIALS,
+            httpx_client_factory=mock_client_factory(handler),
+        )
+        async with client as (read_stream, write_stream, _):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+
+                with pytest.raises(McpError) as rejected:
+                    await session.call_tool('type_text', {'text': 'a' * 20000})
+
+                # The transport survived, so the next call still goes through.
+                result = await session.call_tool('type_text', {'text': 'a'})
+                return rejected.value, result
+
+    # Bounded so a regression fails the test instead of hanging the suite.
+    error, result = await asyncio.wait_for(drive(), timeout=30)
+
+    assert error.error.code == 413
+    assert 'HTTP 413' in str(error)
+    assert result.content[0].text == 'ok'  # type: ignore[union-attr]
+    assert calls[:4] == ['initialize', 'notifications/initialized', 'tools/call', 'tools/call']

--- a/uv.lock
+++ b/uv.lock
@@ -3308,6 +3308,7 @@ dependencies = [
     { name = "boto3" },
     { name = "botocore", extra = ["crt"] },
     { name = "fastmcp" },
+    { name = "httpx" },
 ]
 
 [package.dev-dependencies]
@@ -3329,6 +3330,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.41.0" },
     { name = "botocore", extras = ["crt"], specifier = ">=1.41.0" },
     { name = "fastmcp", specifier = ">=3.2,<3.5" },
+    { name = "httpx", specifier = ">=0.27.1,<1.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

In library mode (`aws_iam_streamablehttp_client`), a non-2xx HTTP response from the endpoint was never delivered to the caller. This was reported against a WAF-protected endpoint that answers oversize request bodies with `413` (empty body, no `content-type`): the tool call never returned. Subprocess mode is unaffected, because `ToolErrorMiddleware` bounds and converts tool-call failures there.

### Root cause

The mcp 1.x streamable HTTP transport calls `raise_for_status()` on any POST reply other than 202/404, from inside the task it spawned for that request. The resulting `HTTPStatusError` therefore tears down the transport task group instead of reaching the request it belongs to, and the caller stays parked in `BaseSession.send_request`, which waits without a timeout by default.

mcp 1.x does have a safety net — `_receive_loop`'s `finally` sends `CONNECTION_CLOSED` to every pending request — but it never lands: `MemoryObjectSendStream.send()` begins with an anyio checkpoint that raises `CancelledError` because the scope is already cancelled, and the surrounding guard is `except Exception`, which does not catch `BaseException`. `_response_streams` is left populated.

### Changes

* `mcp_proxy_for_aws/mcp1_compat.py` — a response hook, registered only on the library path, that rewrites a failed POST into the JSON-RPC error response the waiting request needs. Same design as mcp 2.x: the same `>= 400` boundary, the same rule of answering the pending request id. The module documents that it is temporary and lists what to delete on the mcp 2.x upgrade.
* `mcp_proxy_for_aws/client.py` — one import and one hook registration.
* `pyproject.toml` / `uv.lock` — declare `httpx`, which is used directly throughout but only arrived transitively through `fastmcp` → `mcp`.

Not included: the proxy path is untouched by design, and no dependency version was bumped.

### User experience

Against an endpoint returning `413` for an oversize body, with the session held on a background event loop:

| Caller shape | Before | After |
|---|---|---|
| Bare `ClientSession` (LangChain, LlamaIndex pattern) | Call never returns | `McpError: HTTP 413 Request Entity Too Large from <url>` immediately |
| Strands `MCPClient` | `Tool execution failed: Connection to the MCP server was closed`, and the session is dead — the next call raises `MCPClientInitializationError` | `Tool execution failed: HTTP 413 Request Entity Too Large from <url>`, and the next call succeeds |

The failure now names the HTTP status and the session survives it, so a single rejected request no longer ends the session.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/aws/mcp-proxy-for-aws/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

> Docs intentionally left for a follow-up decision: a README note for the programmatic-access section is drafted but not part of this PR.

Is this a breaking change? (Y/N)

* [ ] Yes
* [x] No

Please add details about how this change was tested.

* 276 unit tests pass; `mcp1_compat.py` at 100% statement and branch coverage.
* The end-to-end regression test fails with `HTTPStatusError` when the hook registration is removed, and the proxy-path guard fails when the hook is wired into `create_sigv4_client`, so both are real guards rather than vacuous assertions.
* Verified against **every mcp 1.x version the pin permits** — 1.24.0 through 1.29.1, ten releases — since the fix leans on SDK internals and a dependency bump could otherwise break it silently. All pass.
* Verified against every stable httpx in the declared range: 0.27.1, 0.27.2, 0.28.0, 0.28.1.
* Reproduced and verified through a real Strands `MCPClient`, one of the documented integrations, in addition to the bare-`ClientSession` shape.

- [x] Did integration tests succeed?
  * `test_library_client_completes_an_exchange` passes against the repo's own `simple_mcp_server` over `REMOTE_ENDPOINT_URL` with real SigV4 signing.
  * https://github.com/aws/mcp-proxy-for-aws/actions/runs/33862820799/job/100990915760
- [x] If the feature is a new use case, is it necessary to add a new integration test case?

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

